### PR TITLE
Improve prompt templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,28 @@ monitored_domains:
 ## Usage
 
 ```bash
-python run.py                    # collect all platforms + build prompt
-python run.py --months 3         # longer lookback window
-python run.py --collect-only     # collect and store data, skip prompt
-python run.py --analyse-only     # build prompt from last saved data
+python run.py                      # collect all platforms + build prompt
+python run.py --months 3           # longer lookback window
+python run.py --collect-only       # collect and store data, skip prompt
+python run.py --analyse-only       # build prompt from last saved data
 python run.py --platform mastodon  # single platform
+python run.py --update             # collect + build a compact update prompt
+python run.py --analyse-only --update  # update prompt from last saved data
 ```
 
-Paste `reports/prompt-YYYY-WNN.txt` into claude.ai to get the report and dashboard. Use **Claude Opus** — it handles the cross-platform analysis and React artifact generation significantly better than Sonnet.
+### First run
+
+Paste `reports/prompt-YYYY-WNN.txt` into a **new** claude.ai chat to get the full report and dashboard. Use **Claude Opus** — it handles cross-platform analysis and React artifact generation significantly better than Sonnet.
+
+### Subsequent weeks — update in the same chat
+
+Instead of starting a new chat each week, run with `--update`:
+
+```bash
+python run.py --update
+```
+
+This generates `reports/prompt-YYYY-WNN-update.txt` — a compact follow-up prompt that tells Claude to update the existing report and dashboard in-place. Paste it into the **same chat** as the original report. This preserves context, keeps the dashboard evolving, and lets Claude compare week-over-week trends directly.
 
 If you haven't run in more than two weeks, the lookback window is automatically extended to cover the gap — no manual `--months` needed.
 
@@ -261,7 +275,7 @@ social-brain/
 ├── analyse.py            # prompt builder
 ├── store.py              # analytics.xlsx upsert logic
 ├── run.py                # CLI entry point
-├── prompts/              # editable prompt templates (preamble.txt, suffix.txt)
+├── prompts/              # editable prompt templates (preamble.txt, suffix.txt, update.txt)
 ├── viz/Dashboard.jsx     # reference template Claude models the artifact on
 ├── tests/                # pytest test suite — no real credentials needed
 ├── data/                 # raw JSON snapshots + analytics.xlsx (gitignored)

--- a/analyse.py
+++ b/analyse.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 PREAMBLE_PATH = PROMPTS_DIR / "preamble.txt"
 SUFFIX_PATH = PROMPTS_DIR / "suffix.txt"
+UPDATE_PATH = PROMPTS_DIR / "update.txt"
 
 # Dashboard reference component — embedded in the prompt so Claude knows the
 # exact structure, charts, tabs, and styling to reproduce as a self-contained artifact.
@@ -250,20 +251,84 @@ def build_prompt(
     return preamble + dashboard_ref + suffix
 
 
+def build_update_prompt(
+    collected_data: dict[str, Any],
+    config: dict[str, Any],
+    period: str,
+    months: int | None = None,
+) -> str:
+    """
+    Build a compact follow-up prompt for use in the same claude.ai chat as the
+    original report. Instructs Claude to update the existing report and dashboard
+    in-place rather than producing a full new analysis from scratch.
+    """
+    if not UPDATE_PATH.exists():
+        logger.warning("prompts/update.txt not found — falling back to full prompt")
+        return build_prompt(collected_data, config, period, months=months)
+
+    period_window = f"{months}-Month" if months else "Weekly"
+
+    collected_at = ""
+    since_date = ""
+    for platform_data in collected_data.values():
+        if isinstance(platform_data, dict):
+            if not collected_at and platform_data.get("collected_at"):
+                collected_at = platform_data["collected_at"][:10]
+            if not since_date and platform_data.get("since"):
+                since_date = platform_data["since"][:10]
+    if not collected_at:
+        collected_at = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    def _fmt_date(iso: str) -> str:
+        try:
+            dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            return dt.strftime("%b %-d %Y")
+        except Exception:
+            return iso
+
+    date_range = f"{_fmt_date(since_date)} – {_fmt_date(collected_at)}" if since_date else collected_at
+    platforms_available = (
+        "\n".join(f"- {p}" for p in collected_data if p != "upcoming")
+        if collected_data else "- (no data collected)"
+    )
+    primary_focus = config.get("primary_focus", "") or "(none specified)"
+    upcoming_section = _format_upcoming_section(collected_data)
+    trimmed = _trim_data(collected_data)
+    data_json = json.dumps(trimmed, indent=2, default=str)
+
+    return UPDATE_PATH.read_text().format(
+        period_id=period,
+        period_window=period_window,
+        date_range=date_range,
+        platforms_available=platforms_available,
+        primary_focus=primary_focus,
+        upcoming_section=upcoming_section,
+        data_json=data_json,
+    )
+
+
 def save_prompt(
     collected_data: dict[str, Any],
     config: dict[str, Any],
     period: str,
     reports_dir: Path,
     months: int | None = None,
+    update: bool = False,
 ) -> Path:
     """
-    Build the analysis prompt and write it to reports/prompt-{period}.txt.
+    Build the analysis prompt and write it to reports/.
+    If update=True, generates a compact follow-up prompt (prompt-{period}-update.txt)
+    for use in the same claude.ai chat as the original report.
     Returns the path to the written file.
     """
-    prompt = build_prompt(collected_data, config, period, months=months)
+    if update:
+        prompt = build_update_prompt(collected_data, config, period, months=months)
+        filename = f"prompt-{period}-update.txt"
+    else:
+        prompt = build_prompt(collected_data, config, period, months=months)
+        filename = f"prompt-{period}.txt"
     reports_dir.mkdir(parents=True, exist_ok=True)
-    path = reports_dir / f"prompt-{period}.txt"
+    path = reports_dir / filename
     path.write_text(prompt)
     logger.info("Prompt saved → %s (%d chars)", path, len(prompt))
     return path

--- a/prompts/preamble.txt
+++ b/prompts/preamble.txt
@@ -23,7 +23,7 @@ Include exactly these sections:
 List only the platforms present in the JSON.
 
 ### 1. What Worked
-Top-performing content. For each item, explain *why* it likely performed well based on the data — engagement type, topic, format, timing. Do not list items without a reason. If amazon data is present, include book sales momentum here — note the best rank achieved and any editions or marketplaces performing notably well.
+Top-performing content. For each item, explain *why* it likely performed well based on the data — engagement type, topic, format, timing. Do not list items without a reason. If oreilly data is present, include book royalties here — summarise total paid and any notable line items.
 
 ### 2. What Didn't
 Underperforming posts or patterns. Brief hypothesis for each. Skip this section if there is genuinely nothing to note.
@@ -40,7 +40,7 @@ Exactly 5 specific content ideas. For each:
 If upcoming scheduled content is listed in the data, treat those as already planned and suggest complementary ideas rather than duplicating them.
 
 ### 5. Metrics Summary
-A single markdown table, one row per platform. Include only platforms in the data. Use "n/a" for fields not available in that platform's data. For mentions, summarise total HN hits, Mastodon mentions, and Bluesky mentions in one row. For jetpack referrers, list the top 3 sources. For amazon, include the best bestseller rank achieved across all editions and marketplaces, plus review count — treat rank as the primary book sales signal.
+A single markdown table, one row per platform. Include only platforms in the data. Use "n/a" for fields not available in that platform's data. For mentions, summarise total HN hits, Mastodon mentions, and Bluesky mentions in one row. For jetpack referrers, list the top 3 sources. For amazon, include the best bestseller rank across all editions and marketplaces, plus review count. For oreilly, include total royalties paid and payment count — this is the actual book sales revenue figure.
 
 ### 6. Tracking Gaps & Recommended Sources
 Look at the primary focus and identify what data is missing that would help measure it better. For each gap:

--- a/prompts/preamble.txt
+++ b/prompts/preamble.txt
@@ -37,6 +37,8 @@ Exactly 5 specific content ideas. For each:
 - Recommended platform(s) — only suggest platforms in the data
 - The signal that justifies it
 
+Ideas 1–4 should be grounded directly in the data. Idea 5 should be a wilder, more experimental concept — something outside the creator's current patterns that the data hints at but doesn't directly support. It should still be plausible and specific, not generic advice.
+
 If upcoming scheduled content is listed in the data, treat those as already planned and suggest complementary ideas rather than duplicating them.
 
 ### 5. Metrics Summary

--- a/prompts/preamble.txt
+++ b/prompts/preamble.txt
@@ -23,7 +23,7 @@ Include exactly these sections:
 List only the platforms present in the JSON.
 
 ### 1. What Worked
-Top-performing content. For each item, explain *why* it likely performed well based on the data — engagement type, topic, format, timing. Do not list items without a reason.
+Top-performing content. For each item, explain *why* it likely performed well based on the data — engagement type, topic, format, timing. Do not list items without a reason. If amazon data is present, include book sales momentum here — note the best rank achieved and any editions or marketplaces performing notably well.
 
 ### 2. What Didn't
 Underperforming posts or patterns. Brief hypothesis for each. Skip this section if there is genuinely nothing to note.
@@ -40,7 +40,7 @@ Exactly 5 specific content ideas. For each:
 If upcoming scheduled content is listed in the data, treat those as already planned and suggest complementary ideas rather than duplicating them.
 
 ### 5. Metrics Summary
-A single markdown table, one row per platform. Include only platforms in the data. Use "n/a" for fields not available in that platform's data. For mentions, summarise total HN hits, Mastodon mentions, and Bluesky mentions in one row. For jetpack referrers, list the top 3 sources.
+A single markdown table, one row per platform. Include only platforms in the data. Use "n/a" for fields not available in that platform's data. For mentions, summarise total HN hits, Mastodon mentions, and Bluesky mentions in one row. For jetpack referrers, list the top 3 sources. For amazon, include the best bestseller rank achieved across all editions and marketplaces, plus review count — treat rank as the primary book sales signal.
 
 ### 6. Tracking Gaps & Recommended Sources
 Look at the primary focus and identify what data is missing that would help measure it better. For each gap:

--- a/prompts/suffix.txt
+++ b/prompts/suffix.txt
@@ -18,12 +18,12 @@ Data shape notes (for interpreting the JSON):
 - buttondown: subscriber_counts per newsletter; newsletters list with open_rate, click_rate, unsubscribes per issue
 - substack: emails list with subject, date, recipients, opens, open_rate, likes, comments, shares, new_signups, new_subscribers per issue
 - vercel: daily_views, visitors, top_pages, referrers, bounce_rate
-- amazon: by_marketplace dict — each marketplace has a list of book editions with best_sellers_rank (lower = better; treat rank as a sales signal — flag notable rank changes or positions), rating, reviews
+- amazon: by_marketplace dict — each marketplace has a list of book editions with best_sellers_rank (lower = better; rank reflects relative popularity, not unit sales), rating, reviews
+- oreilly: payment_count, total_paid, currencies, payments (list of payment_date/amount/currency/line_items objects) — these are actual royalty payments representing real book sales revenue; use oreilly as the primary book sales signal, not amazon rank
 - upcoming: sources.wordpress (scheduled blog posts with title, date, content), sources.buttondown (scheduled emails), sources.buffer (queued social posts with platform, text, scheduled_at)
 - mentions: sources.hacker_news (stories/comments containing monitored domains, with points and num_comments); sources.mastodon / sources.bluesky (@ mention notifications); sources.google_search_console (top queries and pages by clicks)
 - goatcounter: total_pageviews, total_unique, top_paths (page URLs with view counts), events (custom event names with counts — e.g. quiz result distributions)
 - calendly: total_bookings (active), total_canceled, bookings_by_type (list of event_type/active/canceled objects); if lead_gen_event and lead_gen_bookings are present, treat lead_gen_bookings as the primary conversion metric for the period — reference it explicitly when discussing cross-platform patterns and content suggestions
-- oreilly: payment_count, total_paid, currencies, payments (list of payment_date/amount/currency/line_items objects)
 
 Primary focus (what matters most — use this to frame the analysis):
 {primary_focus}

--- a/prompts/suffix.txt
+++ b/prompts/suffix.txt
@@ -18,7 +18,7 @@ Data shape notes (for interpreting the JSON):
 - buttondown: subscriber_counts per newsletter; newsletters list with open_rate, click_rate, unsubscribes per issue
 - substack: emails list with subject, date, recipients, opens, open_rate, likes, comments, shares, new_signups, new_subscribers per issue
 - vercel: daily_views, visitors, top_pages, referrers, bounce_rate
-- amazon: by_marketplace dict — each marketplace has a list of book editions with best_sellers_rank, rating, reviews
+- amazon: by_marketplace dict — each marketplace has a list of book editions with best_sellers_rank (lower = better; treat rank as a sales signal — flag notable rank changes or positions), rating, reviews
 - upcoming: sources.wordpress (scheduled blog posts with title, date, content), sources.buttondown (scheduled emails), sources.buffer (queued social posts with platform, text, scheduled_at)
 - mentions: sources.hacker_news (stories/comments containing monitored domains, with points and num_comments); sources.mastodon / sources.bluesky (@ mention notifications); sources.google_search_console (top queries and pages by clicks)
 - goatcounter: total_pageviews, total_unique, top_paths (page URLs with view counts), events (custom event names with counts — e.g. quiz result distributions)

--- a/prompts/update.txt
+++ b/prompts/update.txt
@@ -1,0 +1,41 @@
+This is a follow-up update to the analytics report in this conversation. New data has been collected for a subsequent period. Please update the report and dashboard artifact in this chat to reflect the new data — do not start a new report from scratch.
+
+Specifically:
+1. Update the report sections (What Worked, What Didn't, Cross-Platform Patterns, Next Period Suggestions, Metrics Summary, Tracking Gaps) to reflect the new period's data. Note any meaningful changes from the previous period where relevant.
+2. Re-render the dashboard artifact with the new period's numbers. Keep the same structure and tabs — just replace the data constants with new values.
+
+Only analyse the platforms listed under "Data collected from". Do not add sections for platforms not in that list.
+
+If lead_gen_bookings is present in the Calendly data, treat it as the primary conversion metric and note any change from the previous period.
+
+---
+
+## New data
+
+PERIOD_ID: {period_id}
+PERIOD_WINDOW: {period_window}
+DATE_RANGE: {date_range}
+
+Data collected from:
+{platforms_available}
+
+Data shape notes (for interpreting the JSON):
+- mastodon: posts sorted by engagement; each post has content, favourites, boosts, replies, has_attachment, attachment_types; account.followers (current count); new_follows and new_follows_count
+- bluesky: posts sorted by engagement; each post has text, likes, reposts, replies; new_follows and new_follows_count when app_password is configured
+- linkedin: daily_engagement (date, impressions, engagements, new_followers); top_posts_by_engagement and top_posts_by_impressions with post text
+- jetpack: daily_views, top_posts, referrers
+- buttondown: subscriber_counts per newsletter; newsletters with open_rate, click_rate, unsubscribes
+- substack: emails with subject, date, recipients, opens, open_rate, likes, comments, shares
+- vercel: daily_views, visitors, top_pages, referrers
+- amazon: by_marketplace dict — each marketplace has book editions with best_sellers_rank (lower = better), rating, reviews
+- goatcounter: total_pageviews, total_unique, top_paths, events
+- calendly: total_bookings, total_canceled, bookings_by_type; lead_gen_bookings is the primary conversion metric if present
+- oreilly: payment_count, total_paid, currencies, payments
+
+Primary focus:
+{primary_focus}
+
+{upcoming_section}---
+
+DATA (JSON):
+{data_json}

--- a/prompts/update.txt
+++ b/prompts/update.txt
@@ -27,10 +27,10 @@ Data shape notes (for interpreting the JSON):
 - buttondown: subscriber_counts per newsletter; newsletters with open_rate, click_rate, unsubscribes
 - substack: emails with subject, date, recipients, opens, open_rate, likes, comments, shares
 - vercel: daily_views, visitors, top_pages, referrers
-- amazon: by_marketplace dict — each marketplace has book editions with best_sellers_rank (lower = better), rating, reviews
+- amazon: by_marketplace dict — each marketplace has book editions with best_sellers_rank (lower = better; rank reflects popularity, not unit sales), rating, reviews
+- oreilly: payment_count, total_paid, currencies, payments (payment_date/amount/currency/line_items) — actual royalty payments = real book sales revenue; use this as the primary book sales signal, not amazon rank
 - goatcounter: total_pageviews, total_unique, top_paths, events
 - calendly: total_bookings, total_canceled, bookings_by_type; lead_gen_bookings is the primary conversion metric if present
-- oreilly: payment_count, total_paid, currencies, payments
 
 Primary focus:
 {primary_focus}

--- a/run.py
+++ b/run.py
@@ -8,6 +8,8 @@ Usage:
     python run.py --collect-only           # collect and save raw data only
     python run.py --analyse-only           # build prompt from most recent saved data
     python run.py --platform mastodon      # collect only one platform
+    python run.py --update                 # collect + build a compact update prompt for the same chat
+    python run.py --analyse-only --update  # update prompt from most recent saved data
 """
 
 from __future__ import annotations
@@ -169,6 +171,11 @@ def parse_args() -> argparse.Namespace:
         metavar="N",
         help="Collect N months of history instead of the default 2-week window.",
     )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Generate a compact follow-up prompt (prompt-YYYY-WNN-update.txt) for use in the same claude.ai chat as the original report.",
+    )
     return parser.parse_args()
 
 
@@ -261,8 +268,11 @@ def main() -> None:
     logger.info("=== Building analysis prompt ===")
     from analyse import save_prompt
 
-    prompt_path = save_prompt(collected, config, period=label, reports_dir=REPORTS_DIR, months=args.months)
-    logger.info("=== Done. Paste %s into claude.ai to get your report ===", prompt_path)
+    prompt_path = save_prompt(collected, config, period=label, reports_dir=REPORTS_DIR, months=args.months, update=args.update)
+    if args.update:
+        logger.info("=== Done. Paste %s into your existing claude.ai chat to update the report ===", prompt_path)
+    else:
+        logger.info("=== Done. Paste %s into claude.ai to get your report ===", prompt_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `--update` flag to generate a compact follow-up prompt (`prompt-YYYY-WNN-update.txt`) for use in the same claude.ai chat as the original report, enabling week-over-week context and comparison
- Fixes book sales framing: O'Reilly royalty payments are the real revenue signal, Amazon rank is relative popularity only
- Makes the 5th content suggestion explicitly wilder and more experimental — still specific and plausible, but outside the creator's current patterns

## Test plan

- [ ] `python run.py --analyse-only` still generates full prompt as before
- [ ] `python run.py --analyse-only --update` generates `prompt-YYYY-WNN-update.txt`
- [ ] Update prompt is shorter and instructs Claude to update in-place rather than start fresh
- [x] All 262 tests pass (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)