### PR TITLE
Add email subscriber and WordPress.com follower counts to Jetpack

### DIFF
--- a/collectors/jetpack.py
+++ b/collectors/jetpack.py
@@ -67,6 +67,20 @@ def collect_jetpack(
             rr.raise_for_status()
             referrers_data = rr.json()
 
+            fe = client.get(
+                f"{base}/followers",
+                params={"type": "email", "max": 0},
+            )
+            fe.raise_for_status()
+            email_followers_data = fe.json()
+
+            fw = client.get(
+                f"{base}/followers",
+                params={"type": "wpcom", "max": 0},
+            )
+            fw.raise_for_status()
+            wpcom_followers_data = fw.json()
+
         daily_views = []
         for row in visits_data.get("data", []):
             if isinstance(row, list) and len(row) >= 2:
@@ -114,12 +128,17 @@ def collect_jetpack(
             reverse=True,
         )[:20]
 
+        email_subscribers = email_followers_data.get("total", 0)
+        wpcom_followers = wpcom_followers_data.get("total", 0)
+
         total_views = sum(d["views"] for d in daily_views)
         logger.info(
-            "Jetpack: collected %d days of data (%d total views, %d referrers)",
+            "Jetpack: collected %d days of data (%d total views, %d referrers, %d email subs, %d wpcom followers)",
             len(daily_views),
             total_views,
             len(referrers),
+            email_subscribers,
+            wpcom_followers,
         )
         return {
             "platform": "jetpack",
@@ -130,6 +149,8 @@ def collect_jetpack(
             "daily_views": daily_views,
             "top_posts": top_posts,
             "referrers": referrers,
+            "email_subscribers": email_subscribers,
+            "wpcom_followers": wpcom_followers,
         }
 
     except Exception as exc:

--- a/prompts/suffix.txt
+++ b/prompts/suffix.txt
@@ -14,7 +14,7 @@ Data shape notes (for interpreting the JSON):
 - mastodon: posts sorted by engagement; each post has content, favourites, boosts, replies, has_attachment, attachment_types; account.followers (current count); new_follows (list of accounts that followed during the period, with followed_at, account handle, display_name, followers count) and new_follows_count
 - bluesky: posts sorted by engagement; each post has text, likes, reposts, replies, has_attachment, attachment_types; new_follows (list with followed_at, handle, display_name, followers count) and new_follows_count when app_password is configured
 - linkedin: daily_engagement (date, impressions, engagements, new_followers); top_posts_by_engagement and top_posts_by_impressions each include post text scraped from the public URL
-- jetpack: daily_views, top_posts (views this period), referrers (traffic sources aggregated across the period, sorted by views)
+- jetpack: daily_views, top_posts (views this period), referrers (traffic sources aggregated across the period, sorted by views), email_subscribers (current email subscriber count), wpcom_followers (current WordPress.com follower count)
 - buttondown: subscriber_counts per newsletter; newsletters list with open_rate, click_rate, unsubscribes per issue
 - substack: emails list with subject, date, recipients, opens, open_rate, likes, comments, shares, new_signups, new_subscribers per issue
 - vercel: daily_views, visitors, top_pages, referrers, bounce_rate

--- a/prompts/update.txt
+++ b/prompts/update.txt
@@ -23,7 +23,7 @@ Data shape notes (for interpreting the JSON):
 - mastodon: posts sorted by engagement; each post has content, favourites, boosts, replies, has_attachment, attachment_types; account.followers (current count); new_follows and new_follows_count
 - bluesky: posts sorted by engagement; each post has text, likes, reposts, replies; new_follows and new_follows_count when app_password is configured
 - linkedin: daily_engagement (date, impressions, engagements, new_followers); top_posts_by_engagement and top_posts_by_impressions with post text
-- jetpack: daily_views, top_posts, referrers
+- jetpack: daily_views, top_posts, referrers, email_subscribers, wpcom_followers
 - buttondown: subscriber_counts per newsletter; newsletters with open_rate, click_rate, unsubscribes
 - substack: emails with subject, date, recipients, opens, open_rate, likes, comments, shares
 - vercel: daily_views, visitors, top_pages, referrers

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -357,6 +357,12 @@ class TestCollectJetpack:
                 {"name": "google.com", "total": 50},
             ]}}})
         )
+        respx_mock.get(f"{self.BASE}/followers", params={"type": "email", "max": 0}).mock(
+            return_value=httpx.Response(200, json={"total": 427, "subscribers": []})
+        )
+        respx_mock.get(f"{self.BASE}/followers", params={"type": "wpcom", "max": 0}).mock(
+            return_value=httpx.Response(200, json={"total": 52, "subscribers": []})
+        )
 
     def test_happy_path(self, respx_mock):
         self._mock_all(respx_mock)
@@ -388,6 +394,12 @@ class TestCollectJetpack:
         result = collect_jetpack("cate.blog", "token", since=SINCE)
         assert len(result["top_posts"]) == 1
         assert result["top_posts"][0]["views"] == 80  # 50 + 30 aggregated
+
+    def test_subscriber_counts_returned(self, respx_mock):
+        self._mock_all(respx_mock)
+        result = collect_jetpack("cate.blog", "token", since=SINCE)
+        assert result["email_subscribers"] == 427
+        assert result["wpcom_followers"] == 52
 
     def test_auth_failure_returns_none(self, respx_mock):
         respx_mock.get(f"{self.BASE}/visits").mock(return_value=httpx.Response(401))


### PR DESCRIPTION
## Summary
- Fetches `/stats/followers?type=email` and `?type=wpcom` from the WordPress.com REST API
- Adds `email_subscribers` and `wpcom_followers` to the Jetpack collector result
- Updates data shape notes in `prompts/suffix.txt` and `prompts/update.txt`

## Test plan
- [ ] New `test_subscriber_counts_returned` test verifies both counts appear in the result
- [ ] All 263 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)