### PR TITLE
Fix upcoming collector: fetch scheduled emails from all Buttondown newsletters

### DIFF
--- a/collectors/upcoming.py
+++ b/collectors/upcoming.py
@@ -55,27 +55,41 @@ def collect_upcoming(
         except Exception as exc:
             logger.error("Upcoming/WordPress failed: %s", exc)
 
-    # --- Buttondown scheduled emails ---
+    # --- Buttondown scheduled emails (all newsletters) ---
     if buttondown_api_key:
         try:
             r = httpx.get(
-                "https://api.buttondown.email/v1/emails",
-                params={"status": "scheduled"},
+                "https://api.buttondown.email/v1/newsletters",
                 headers={"Authorization": f"Token {buttondown_api_key}"},
                 timeout=30,
             )
             r.raise_for_status()
-            raw_emails = r.json().get("results", [])
-            emails = [
-                {
-                    "subject": e.get("subject", ""),
-                    "scheduled_date": e.get("publish_date") or e.get("creation_date", ""),
-                    "content": _strip_html(e.get("body", "")),
-                }
-                for e in raw_emails
-            ]
-            sources["buttondown"] = emails
-            logger.info("Upcoming: %d scheduled Buttondown emails", len(emails))
+            newsletters = r.json().get("results", [])
+
+            all_scheduled: list[dict] = []
+            for nl in newsletters:
+                nl_name = nl.get("name", nl.get("domain", nl["id"]))
+                nl_key = nl.get("api_key", buttondown_api_key)
+                try:
+                    r = httpx.get(
+                        "https://api.buttondown.email/v1/emails",
+                        params={"status": "scheduled"},
+                        headers={"Authorization": f"Token {nl_key}"},
+                        timeout=30,
+                    )
+                    r.raise_for_status()
+                    for e in r.json().get("results", []):
+                        all_scheduled.append({
+                            "newsletter": nl_name,
+                            "subject": e.get("subject", ""),
+                            "scheduled_date": e.get("publish_date") or e.get("creation_date", ""),
+                            "content": _strip_html(e.get("body", "")),
+                        })
+                except Exception as exc:
+                    logger.warning("Upcoming/Buttondown [%s] failed: %s", nl_name, exc)
+
+            sources["buttondown"] = all_scheduled
+            logger.info("Upcoming: %d scheduled Buttondown emails across %d newsletters", len(all_scheduled), len(newsletters))
         except Exception as exc:
             logger.error("Upcoming/Buttondown failed: %s", exc)
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -23,6 +23,7 @@ from collect import (
     collect_linkedin,
     collect_mastodon,
     collect_mentions,
+    collect_upcoming,
     collect_vercel,
     collect_all,
 )
@@ -1295,3 +1296,122 @@ class TestCollectCalendly:
         result = collect_calendly("tok", since=SINCE)
         assert "lead_gen_bookings" not in result
         assert "lead_gen_event" not in result
+
+
+# ---------------------------------------------------------------------------
+# Upcoming
+# ---------------------------------------------------------------------------
+
+def _buttondown_newsletters_mock(respx_mock, newsletters):
+    respx_mock.get("https://api.buttondown.email/v1/newsletters").mock(
+        return_value=httpx.Response(200, json={"results": newsletters})
+    )
+
+
+def _buttondown_scheduled_mock(respx_mock, emails, api_key=None):
+    """Mock scheduled emails endpoint. If api_key given, match on Authorization header."""
+    def handler(request):
+        if api_key and request.headers.get("authorization") != f"Token {api_key}":
+            return httpx.Response(401)
+        return httpx.Response(200, json={"results": emails})
+    respx_mock.get("https://api.buttondown.email/v1/emails").mock(side_effect=handler)
+
+
+class TestCollectUpcoming:
+    def _newsletter(self, name="My Newsletter", api_key="nl-key-1"):
+        return {"id": "nl-1", "name": name, "api_key": api_key}
+
+    def _scheduled_email(self, subject="Upcoming Issue", date="2026-03-15T10:00:00Z"):
+        return {"subject": subject, "publish_date": date, "body": "<p>Hello</p>"}
+
+    def test_returns_none_when_no_sources_configured(self, respx_mock):
+        result = collect_upcoming()
+        assert result is None
+
+    def test_collects_scheduled_emails_from_all_newsletters(self, respx_mock):
+        newsletters = [
+            {"id": "nl-1", "name": "Newsletter A", "api_key": "key-a"},
+            {"id": "nl-2", "name": "Newsletter B", "api_key": "key-b"},
+        ]
+        _buttondown_newsletters_mock(respx_mock, newsletters)
+
+        def scheduled_handler(request):
+            auth = request.headers.get("authorization", "")
+            if auth == "Token key-a":
+                return httpx.Response(200, json={"results": [self._scheduled_email("Issue A")]})
+            elif auth == "Token key-b":
+                return httpx.Response(200, json={"results": [self._scheduled_email("Issue B")]})
+            return httpx.Response(401)
+
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(side_effect=scheduled_handler)
+
+        result = collect_upcoming(buttondown_api_key="master-key")
+        assert result is not None
+        emails = result["sources"]["buttondown"]
+        assert len(emails) == 2
+        subjects = {e["subject"] for e in emails}
+        assert subjects == {"Issue A", "Issue B"}
+
+    def test_includes_newsletter_name_in_each_email(self, respx_mock):
+        _buttondown_newsletters_mock(respx_mock, [self._newsletter("DRI Your Career", "dri-key")])
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(
+            return_value=httpx.Response(200, json={"results": [self._scheduled_email()]})
+        )
+        result = collect_upcoming(buttondown_api_key="master-key")
+        email = result["sources"]["buttondown"][0]
+        assert email["newsletter"] == "DRI Your Career"
+
+    def test_strips_html_from_content(self, respx_mock):
+        _buttondown_newsletters_mock(respx_mock, [self._newsletter()])
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(
+            return_value=httpx.Response(200, json={"results": [self._scheduled_email()]})
+        )
+        result = collect_upcoming(buttondown_api_key="master-key")
+        email = result["sources"]["buttondown"][0]
+        assert "<p>" not in email["content"]
+        assert "Hello" in email["content"]
+
+    def test_no_scheduled_emails_returns_empty_list(self, respx_mock):
+        _buttondown_newsletters_mock(respx_mock, [self._newsletter()])
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        result = collect_upcoming(buttondown_api_key="master-key")
+        assert result["sources"]["buttondown"] == []
+
+    def test_no_newsletters_returns_empty_list(self, respx_mock):
+        _buttondown_newsletters_mock(respx_mock, [])
+        result = collect_upcoming(buttondown_api_key="master-key")
+        assert result["sources"]["buttondown"] == []
+
+    def test_one_newsletter_failure_doesnt_stop_others(self, respx_mock):
+        newsletters = [
+            {"id": "nl-1", "name": "Good Newsletter", "api_key": "good-key"},
+            {"id": "nl-2", "name": "Bad Newsletter", "api_key": "bad-key"},
+        ]
+        _buttondown_newsletters_mock(respx_mock, newsletters)
+
+        def handler(request):
+            auth = request.headers.get("authorization", "")
+            if auth == "Token good-key":
+                return httpx.Response(200, json={"results": [self._scheduled_email("Good Issue")]})
+            return httpx.Response(500)
+
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(side_effect=handler)
+
+        result = collect_upcoming(buttondown_api_key="master-key")
+        assert result is not None
+        emails = result["sources"]["buttondown"]
+        assert len(emails) == 1
+        assert emails[0]["subject"] == "Good Issue"
+
+    def test_newsletters_api_failure_logs_error(self, respx_mock):
+        respx_mock.get("https://api.buttondown.email/v1/newsletters").mock(
+            return_value=httpx.Response(401)
+        )
+        result = collect_upcoming(buttondown_api_key="bad-key")
+        assert result is None
+
+    def test_skips_buttondown_when_no_key(self, respx_mock):
+        result = collect_upcoming(buttondown_api_key="")
+        assert result is None


### PR DESCRIPTION
## Summary
- The upcoming collector was only fetching scheduled Buttondown emails for the one newsletter associated with the configured API key
- Now discovers all newsletters via `GET /v1/newsletters` first, then fetches scheduled emails from each using their individual keys — the same approach the main `collect_buttondown` function already uses
- Adds a `newsletter` field to each scheduled email entry so the source is identifiable
- No config changes needed — the existing single `buttondown_api_key` works for discovery

## Test plan
- [ ] 275 tests pass (`python3 -m pytest`)
- [ ] 9 new tests added for `collect_upcoming` (previously had no coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)