### PR TITLE
Reduce prompt size ~60% and reference dashboard from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ python run.py --analyse-only --update  # update prompt from last saved data
 
 ### First run
 
-Paste `reports/prompt-YYYY-WNN.txt` into a **new** claude.ai chat to get the full report and dashboard. Use **Claude Opus** — it handles cross-platform analysis and React artifact generation significantly better than Sonnet.
+Paste `reports/prompt-YYYY-WNN.txt` into a **new** claude.ai chat to get the full report and dashboard. Use **Claude Opus** — it handles cross-platform analysis and React artifact generation significantly better than Sonnet. The prompt instructs Claude to fetch the dashboard template from this repo, so web access must be enabled in your claude.ai settings.
 
 ### Starting a fresh chat (context window reset)
 

--- a/analyse.py
+++ b/analyse.py
@@ -78,12 +78,14 @@ def _strip_html(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
-def _trim_data(data: dict[str, Any]) -> dict[str, Any]:
+def _trim_data(data: dict[str, Any], months: int | None = None) -> dict[str, Any]:
     """
     Return a copy of collected data with HTML stripped from post content
     and long text fields truncated, to keep the prompt a manageable size.
+    Pass months to allow larger post lists for longer lookback windows.
     """
     data = copy.deepcopy(data)
+    linkedin_post_limit = 25 if months else 15
 
     # Mastodon: strip HTML, truncate, drop non-analytics fields, keep top 15 by engagement
     mastodon_posts = data.get("mastodon", {}).get("posts", [])
@@ -121,7 +123,7 @@ def _trim_data(data: dict[str, Any]) -> dict[str, Any]:
         for post in eng_posts:
             post["text"] = _strip_html(post.get("text", ""))[:300]
             post.pop("url", None)
-        li["top_posts_by_engagement"] = eng_posts[:15]
+        li["top_posts_by_engagement"] = eng_posts[:linkedin_post_limit]
         li["top_posts_by_impressions_note"] = "Omitted — see top_posts_by_engagement for post content"
         li.pop("top_posts_by_impressions", None)
 
@@ -248,7 +250,7 @@ def build_prompt(
 
     primary_focus = config.get("primary_focus", "") or "(none specified)"
 
-    trimmed = _trim_data(collected_data)
+    trimmed = _trim_data(collected_data, months=months)
     data_json = json.dumps(trimmed, indent=2, default=str)
     upcoming_section = _format_upcoming_section(collected_data)
 
@@ -314,7 +316,7 @@ def build_update_prompt(
     )
     primary_focus = config.get("primary_focus", "") or "(none specified)"
     upcoming_section = _format_upcoming_section(collected_data)
-    trimmed = _trim_data(collected_data)
+    trimmed = _trim_data(collected_data, months=months)
     data_json = json.dumps(trimmed, indent=2, default=str)
 
     return UPDATE_PATH.read_text().format(

--- a/analyse.py
+++ b/analyse.py
@@ -230,12 +230,11 @@ def build_prompt(
     data_json = json.dumps(trimmed, indent=2, default=str)
     upcoming_section = _format_upcoming_section(collected_data)
 
-    # --- Assemble prompt (Dashboard.jsx inserted as plain string to avoid brace conflicts) ---
+    # --- Assemble prompt ---
     preamble = _read_preamble().format(
         period_window=period_window,
         period_id=period,
     )
-    dashboard_ref = _read_dashboard_reference()
     suffix = _read_suffix().format(
         period_id=period,
         period_window=period_window,
@@ -248,7 +247,7 @@ def build_prompt(
         data_json=data_json,
     )
 
-    return preamble + dashboard_ref + suffix
+    return preamble + suffix
 
 
 def build_update_prompt(

--- a/analyse.py
+++ b/analyse.py
@@ -85,7 +85,7 @@ def _trim_data(data: dict[str, Any]) -> dict[str, Any]:
     """
     data = copy.deepcopy(data)
 
-    # Mastodon: strip HTML, truncate, drop non-analytics fields, keep top 30 by engagement
+    # Mastodon: strip HTML, truncate, drop non-analytics fields, keep top 15 by engagement
     mastodon_posts = data.get("mastodon", {}).get("posts", [])
     for post in mastodon_posts:
         post["content"] = _strip_html(post.get("content", ""))[:200]
@@ -96,10 +96,10 @@ def _trim_data(data: dict[str, Any]) -> dict[str, Any]:
         reverse=True,
     )
     if "mastodon" in data:
-        data["mastodon"]["posts"] = mastodon_posts[:30]
-        data["mastodon"]["note"] = f"Showing top 30 of {len(mastodon_posts)} posts by engagement"
+        data["mastodon"]["posts"] = mastodon_posts[:15]
+        data["mastodon"]["note"] = f"Showing top 15 of {len(mastodon_posts)} posts by engagement"
 
-    # Bluesky: truncate text, drop URI, keep top 30 by engagement
+    # Bluesky: truncate text, drop URI, keep top 15 by engagement
     bluesky_posts = data.get("bluesky", {}).get("posts", [])
     for post in bluesky_posts:
         post["text"] = post.get("text", "")[:200]
@@ -109,8 +109,30 @@ def _trim_data(data: dict[str, Any]) -> dict[str, Any]:
         reverse=True,
     )
     if "bluesky" in data:
-        data["bluesky"]["posts"] = bluesky_posts[:30]
-        data["bluesky"]["note"] = f"Showing top 30 of {len(bluesky_posts)} posts by engagement"
+        data["bluesky"]["posts"] = bluesky_posts[:15]
+        data["bluesky"]["note"] = f"Showing top 15 of {len(bluesky_posts)} posts by engagement"
+
+    # LinkedIn: truncate post text, deduplicate the two top-post lists, cap daily data
+    if "linkedin" in data:
+        li = data["linkedin"]
+
+        # Truncate post text and keep top 15 by engagement; drop impressions list (overlaps heavily)
+        eng_posts = li.get("top_posts_by_engagement", [])
+        for post in eng_posts:
+            post["text"] = _strip_html(post.get("text", ""))[:300]
+            post.pop("url", None)
+        li["top_posts_by_engagement"] = eng_posts[:15]
+        li["top_posts_by_impressions_note"] = "Omitted — see top_posts_by_engagement for post content"
+        li.pop("top_posts_by_impressions", None)
+
+        # Cap daily engagement to 30 most recent days
+        daily = li.get("daily_engagement", [])
+        if len(daily) > 30:
+            li["daily_engagement"] = daily[-30:]
+            li["daily_engagement_note"] = f"Showing most recent 30 of {len(daily)} days"
+
+        # Drop demographics — not needed for content analysis
+        li.pop("demographics", None)
 
     # Buttondown: drop full body — not useful for analytics
     for email in data.get("buttondown", {}).get("newsletters", []):

--- a/prompts/preamble.txt
+++ b/prompts/preamble.txt
@@ -61,7 +61,7 @@ Produce a single self-contained React component that renders the analytics dashb
 Rules:
 - Start with `import React, {{ useState }} from "react"` and `import {{ LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, ReferenceLine, Legend, Cell, ComposedChart }} from "recharts"` — recharts is available in artifacts.
 - Do NOT import from any external file. All data must be defined as constants at the top of the file (PERIOD_LABEL, STATS, blogDaily, linkedinDaily, mastodonPosts, vercelDaily, vercelReferrers, blogTopPosts, amazonBooks, newsletterIssues, funnelNorm, funnelInsights, calendlyByType, goatcounterEvents).
-- Model the structure, tabs, charts, colours, and styling exactly on the reference Dashboard.jsx below. Export a default function named Dashboard.
+- Model the structure, tabs, charts, colours, and styling exactly on the reference Dashboard.jsx at https://raw.githubusercontent.com/catehstn/social-brain/main/viz/Dashboard.jsx — fetch it and use it as your template. Export a default function named Dashboard.
 - Replace all placeholder values with real numbers from the JSON. Do not invent numbers. Use 0 or "n/a" for unavailable values.
 - Only include tabs for platforms that have data. Omit tabs entirely for missing platforms rather than showing empty sections.
 - blogDaily, linkedinDaily, vercelDaily: include all days in the period as {{d: "Mon DD", ...}} objects.
@@ -75,5 +75,4 @@ Rules:
 - If goatcounter data is present, include it in the Web tab — show total pageviews/unique visitors and a bar chart of top_paths. If events are present (e.g. quiz result distribution), add a small events breakdown chart. Define event data as goatcounterEvents.
 - When writing any text content into a JS double-quoted string literal, escape any double quotes in the content (replace " with \"). For example: `label: "She said \"hello\""`. This applies to post labels, titles, subjects, and any other text fields.
 
-Reference Dashboard.jsx:
 

--- a/prompts/update.txt
+++ b/prompts/update.txt
@@ -2,7 +2,7 @@ This is a follow-up update to the analytics report in this conversation. New dat
 
 Specifically:
 1. Update the report sections (What Worked, What Didn't, Cross-Platform Patterns, Next Period Suggestions, Metrics Summary, Tracking Gaps) to reflect the new period's data. Note any meaningful changes from the previous period where relevant.
-2. Re-render the dashboard artifact with the new period's numbers. Keep the same structure and tabs — just replace the data constants with new values.
+2. Re-render the dashboard artifact with the new period's numbers. Keep the same structure and tabs — just replace the data constants with new values. The reference template is at https://raw.githubusercontent.com/catehstn/social-brain/main/viz/Dashboard.jsx if you need to check the structure.
 
 Only analyse the platforms listed under "Data collected from". Do not add sections for platforms not in that list.
 

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -167,11 +167,11 @@ class TestTrimData:
         scores = [p["favourites"] for p in result["mastodon"]["posts"]]
         assert scores == sorted(scores, reverse=True)
 
-    def test_mastodon_caps_at_30(self):
+    def test_mastodon_caps_at_15(self):
         posts = [self._mastodon_post(favourites=i) for i in range(50)]
         data = {"mastodon": {"posts": posts}}
         result = analyse._trim_data(data)
-        assert len(result["mastodon"]["posts"]) == 30
+        assert len(result["mastodon"]["posts"]) == 15
 
     def test_mastodon_note_added(self):
         posts = [self._mastodon_post() for _ in range(5)]
@@ -201,11 +201,11 @@ class TestTrimData:
         scores = [p["likes"] for p in result["bluesky"]["posts"]]
         assert scores == sorted(scores, reverse=True)
 
-    def test_bluesky_caps_at_30(self):
+    def test_bluesky_caps_at_15(self):
         posts = [self._bluesky_post(likes=i) for i in range(50)]
         data = {"bluesky": {"posts": posts}}
         result = analyse._trim_data(data)
-        assert len(result["bluesky"]["posts"]) == 30
+        assert len(result["bluesky"]["posts"]) == 15
 
     def test_bluesky_note_added(self):
         data = {"bluesky": {"posts": [self._bluesky_post()]}}
@@ -272,6 +272,97 @@ class TestTrimData:
     def test_empty_data_no_crash(self):
         result = analyse._trim_data({})
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _trim_data — LinkedIn
+# ---------------------------------------------------------------------------
+
+class TestTrimDataLinkedIn:
+    def _linkedin_post(self, text="Post text", impressions=100, engagements=10):
+        return {"text": text, "impressions": impressions, "engagements": engagements}
+
+    def _linkedin_data(self, num_posts=5, num_daily=10):
+        return {
+            "linkedin": {
+                "top_posts_by_engagement": [self._linkedin_post() for _ in range(num_posts)],
+                "top_posts_by_impressions": [self._linkedin_post() for _ in range(num_posts)],
+                "daily_engagement": [{"date": f"2025-01-{i+1:02d}", "impressions": i} for i in range(num_daily)],
+                "demographics": {"seniority": {"Senior": 0.4}},
+            }
+        }
+
+    def test_drops_impressions_list(self):
+        data = self._linkedin_data()
+        result = analyse._trim_data(data)
+        assert "top_posts_by_impressions" not in result["linkedin"]
+
+    def test_adds_impressions_note(self):
+        data = self._linkedin_data()
+        result = analyse._trim_data(data)
+        assert "top_posts_by_impressions_note" in result["linkedin"]
+
+    def test_drops_demographics(self):
+        data = self._linkedin_data()
+        result = analyse._trim_data(data)
+        assert "demographics" not in result["linkedin"]
+
+    def test_caps_engagement_posts_at_15_weekly(self):
+        data = self._linkedin_data(num_posts=50)
+        result = analyse._trim_data(data)
+        assert len(result["linkedin"]["top_posts_by_engagement"]) == 15
+
+    def test_caps_engagement_posts_at_25_monthly(self):
+        data = self._linkedin_data(num_posts=50)
+        result = analyse._trim_data(data, months=3)
+        assert len(result["linkedin"]["top_posts_by_engagement"]) == 25
+
+    def test_truncates_post_text(self):
+        long_text = "x" * 1000
+        data = {"linkedin": {
+            "top_posts_by_engagement": [self._linkedin_post(text=long_text)],
+            "top_posts_by_impressions": [],
+            "daily_engagement": [],
+        }}
+        result = analyse._trim_data(data)
+        assert len(result["linkedin"]["top_posts_by_engagement"][0]["text"]) <= 300
+
+    def test_drops_post_url(self):
+        data = {"linkedin": {
+            "top_posts_by_engagement": [{"text": "hi", "url": "https://linkedin.com/post/123"}],
+            "top_posts_by_impressions": [],
+            "daily_engagement": [],
+        }}
+        result = analyse._trim_data(data)
+        assert "url" not in result["linkedin"]["top_posts_by_engagement"][0]
+
+    def test_caps_daily_engagement_at_30(self):
+        data = self._linkedin_data(num_daily=60)
+        result = analyse._trim_data(data)
+        assert len(result["linkedin"]["daily_engagement"]) == 30
+
+    def test_daily_engagement_note_added_when_capped(self):
+        data = self._linkedin_data(num_daily=60)
+        result = analyse._trim_data(data)
+        assert "daily_engagement_note" in result["linkedin"]
+
+    def test_daily_engagement_keeps_most_recent(self):
+        days = [{"date": f"day-{i}", "impressions": i} for i in range(60)]
+        data = {"linkedin": {
+            "top_posts_by_engagement": [],
+            "top_posts_by_impressions": [],
+            "daily_engagement": days,
+        }}
+        result = analyse._trim_data(data)
+        kept = result["linkedin"]["daily_engagement"]
+        # Should keep the last 30 (most recent)
+        assert kept[0]["date"] == "day-30"
+        assert kept[-1]["date"] == "day-59"
+
+    def test_no_crash_when_linkedin_missing_keys(self):
+        data = {"linkedin": {}}
+        result = analyse._trim_data(data)
+        assert "linkedin" in result
 
 
 # ---------------------------------------------------------------------------
@@ -483,10 +574,11 @@ class TestBuildPrompt:
             result = analyse.build_prompt({}, config, "2025-W23")
         assert "(none specified)" in result
 
-    def test_dashboard_content_in_prompt(self, tmp_path):
-        with patch_templates(tmp_path):
-            result = analyse.build_prompt({}, self._base_config(), "2025-W23")
-        assert "// stub dashboard" in result
+    def test_dashboard_github_url_in_preamble(self):
+        # The real preamble.txt must reference the public GitHub repo
+        preamble = analyse.PREAMBLE_PATH.read_text()
+        assert "catehstn/social-brain" in preamble
+        assert "Dashboard.jsx" in preamble
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **60% prompt size reduction**: LinkedIn data was completely untrimmed and dominated prompt size at 53K chars. Now trims post count (15 weekly / 25 monthly), removes the duplicate impressions list, caps daily engagement at 30 days, and drops demographics
- **Mastodon/Bluesky**: top posts reduced from 30 → 15 (dashboard only uses 9)
- **Dashboard template**: referenced from public GitHub URL instead of embedded in the prompt, keeping prompts shorter and always pointing to the latest version
- **Fresh chat docs**: documents `--analyse-only` as the way to regenerate a full prompt after a context window reset
- **Note**: web access must be enabled in claude.ai for the dashboard template fetch

## Test plan

- [x] All 286 tests passing
- [x] `python3 run.py --analyse-only` runs cleanly on real data (110K → 44K JSON)
- [x] LinkedIn trimming verified: 15 posts, impressions list gone, demographics gone, 30 daily rows
- [x] GitHub URL present in prompt, no embedded JSX