### PR TITLE
Data quality: stale drop warnings, Calendly filtering, dashboard update fix

### DIFF
--- a/collectors/calendly.py
+++ b/collectors/calendly.py
@@ -65,15 +65,22 @@ def collect_calendly(
             r.raise_for_status()
             canceled_events = r.json().get("collection", [])
 
+        # If a lead_gen_event is specified, restrict counting to that event type only
+        def _event_name(event: dict) -> str:
+            et_uri = event.get("event_type", "")
+            return event_type_names.get(et_uri, et_uri.split("/")[-1])
+
+        if lead_gen_event:
+            active_events = [e for e in active_events if _event_name(e) == lead_gen_event]
+            canceled_events = [e for e in canceled_events if _event_name(e) == lead_gen_event]
+
         # Aggregate by event type
         by_type: dict[str, dict[str, int]] = {}
         for event in active_events:
-            et_uri = event.get("event_type", "")
-            name = event_type_names.get(et_uri, et_uri.split("/")[-1])
+            name = _event_name(event)
             by_type.setdefault(name, {"active": 0, "canceled": 0})["active"] += 1
         for event in canceled_events:
-            et_uri = event.get("event_type", "")
-            name = event_type_names.get(et_uri, et_uri.split("/")[-1])
+            name = _event_name(event)
             by_type.setdefault(name, {"active": 0, "canceled": 0})["canceled"] += 1
 
         bookings_by_type = [

--- a/collectors/linkedin.py
+++ b/collectors/linkedin.py
@@ -225,12 +225,12 @@ def collect_linkedin(linkedin_drops_dir: str | Path = "linkedin_drops") -> dict[
 
     export_path = export_files[0]
     file_age = _utcnow() - datetime.fromtimestamp(export_path.stat().st_mtime, tz=timezone.utc)
-    if file_age > timedelta(weeks=2):
+    if file_age > timedelta(hours=24):
         logger.warning(
-            "LinkedIn: export file %s is %d days old — data may be missing recent activity. "
-            "Consider downloading a fresh export.",
+            "LinkedIn: export file %s is %d days old (%.0f hours) — download a fresh export from LinkedIn before running.",
             export_path.name,
             file_age.days,
+            file_age.total_seconds() / 3600,
         )
     logger.info("LinkedIn: reading %s", export_path)
 

--- a/collectors/oreilly.py
+++ b/collectors/oreilly.py
@@ -159,6 +159,15 @@ def collect_oreilly(oreilly_drops_dir: str | Path = "oreilly_drops") -> dict[str
 
     payments.sort(key=lambda p: p["payment_date"])
 
+    most_recent_date = datetime.strptime(payments[-1]["payment_date"], "%Y-%m-%d")
+    days_since = (_utcnow().replace(tzinfo=None) - most_recent_date).days
+    if days_since >= 25:
+        logger.warning(
+            "O'Reilly: most recent payment was %d days ago (%s) — check your email for a new remittance statement.",
+            days_since,
+            payments[-1]["payment_date"],
+        )
+
     total_paid = sum(p["amount"] for p in payments)
     currencies = list({p["currency"] for p in payments if p["currency"]})
 

--- a/collectors/substack.py
+++ b/collectors/substack.py
@@ -35,12 +35,12 @@ def collect_substack(substack_drops_dir: str | Path = "substack_drops") -> dict[
 
     csv_path = csv_files[0]
     file_age = _utcnow() - datetime.fromtimestamp(csv_path.stat().st_mtime, tz=timezone.utc)
-    if file_age > timedelta(weeks=2):
+    if file_age > timedelta(hours=24):
         logger.warning(
-            "Substack: export file %s is %d days old — data may be missing recent activity. "
-            "Consider downloading a fresh export.",
+            "Substack: export file %s is %d days old (%.0f hours) — download a fresh export from Substack before running.",
             csv_path.name,
             file_age.days,
+            file_age.total_seconds() / 3600,
         )
     logger.info("Substack: reading %s", csv_path)
 

--- a/prompts/update.txt
+++ b/prompts/update.txt
@@ -2,7 +2,7 @@ This is a follow-up update to the analytics report in this conversation. New dat
 
 Specifically:
 1. Update the report sections (What Worked, What Didn't, Cross-Platform Patterns, Next Period Suggestions, Metrics Summary, Tracking Gaps) to reflect the new period's data. Note any meaningful changes from the previous period where relevant.
-2. Re-render the dashboard artifact with the new period's numbers. Keep the same structure and tabs — just replace the data constants with new values. The reference template is at https://raw.githubusercontent.com/catehstn/social-brain/main/viz/Dashboard.jsx if you need to check the structure.
+2. Edit the existing dashboard artifact — do NOT create a new artifact or rewrite it from scratch. Open the existing artifact and change ONLY the data constants at the top (PERIOD_LABEL, STATS, blogDaily, linkedinDaily, mastodonPosts, vercelDaily, vercelReferrers, blogTopPosts, amazonBooks, newsletterIssues, funnelNorm, funnelInsights, calendlyByType, goatcounterEvents). Do not alter component structure, chart configuration, tabs, colours, or any code outside the data constants.
 
 Only analyse the platforms listed under "Data collected from". Do not add sections for platforms not in that list.
 

--- a/run.py
+++ b/run.py
@@ -123,6 +123,52 @@ def load_latest_raw() -> tuple[dict, str]:
         return json.load(f), label
 
 
+def check_drop_staleness() -> list[str]:
+    """
+    Check file-drop directories for stale exports.
+    Returns a list of warning strings for any that are out of date.
+    Only warns if files exist (i.e. the user has previously dropped exports).
+    """
+    now = datetime.now(timezone.utc)
+    warnings: list[str] = []
+
+    def _most_recent(*globs: str) -> Path | None:
+        files = []
+        for g in globs:
+            parts = g.rsplit("/", 1)
+            if len(parts) == 2:
+                files.extend(Path(parts[0]).glob(parts[1]) if Path(parts[0]).exists() else [])
+            else:
+                files.extend(Path(".").glob(g))
+        return max(files, key=lambda p: p.stat().st_mtime) if files else None
+
+    # LinkedIn and Substack: must be < 24 hours old
+    for label, *globs in [
+        ("LinkedIn", "linkedin_drops/*.csv", "linkedin_drops/*.xlsx"),
+        ("Substack", "substack_drops/*.csv"),
+    ]:
+        newest = _most_recent(*globs)
+        if newest:
+            age = now - datetime.fromtimestamp(newest.stat().st_mtime, tz=timezone.utc)
+            if age > timedelta(hours=24):
+                hours = age.total_seconds() / 3600
+                warnings.append(
+                    f"{label}: export '{newest.name}' is {hours:.0f}h old — download a fresh export first."
+                )
+
+    # O'Reilly: warn if most recent .eml is > 25 days old (monthly payment cycle)
+    newest_or = _most_recent("oreilly_drops/*.eml")
+    if newest_or:
+        age = now - datetime.fromtimestamp(newest_or.stat().st_mtime, tz=timezone.utc)
+        if age > timedelta(days=25):
+            warnings.append(
+                f"O'Reilly: most recent statement '{newest_or.name}' is {age.days} days old — "
+                f"check your email for a new remittance statement."
+            )
+
+    return warnings
+
+
 def since_last_run() -> datetime | None:
     """
     Return the mtime of the most recent snapshot if it's older than 2 weeks,
@@ -200,6 +246,23 @@ def main() -> None:
             logger.info("Last run was %s — extending lookback to cover gap", gap.date())
 
     label = week_label(months=args.months)
+
+    # ------------------------------------------------------------------
+    # Staleness check
+    # ------------------------------------------------------------------
+    if not args.analyse_only:
+        stale = check_drop_staleness()
+        if stale:
+            print("\nWarning: stale data detected:")
+            for w in stale:
+                print(f"  • {w}")
+            try:
+                answer = input("\nContinue anyway? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = ""
+            if answer != "y":
+                logger.info("Aborted by user.")
+                sys.exit(0)
 
     # ------------------------------------------------------------------
     # Collection

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -463,6 +463,26 @@ class TestCollectLinkedin:
             collect_linkedin(linkedin_drops_dir=tmp_path)
         assert not any("days old" in r.message for r in caplog.records)
 
+    def test_file_under_24h_no_stale_warning(self, tmp_path, caplog):
+        import logging, os
+        export = tmp_path / "export.csv"
+        self._write_csv(export, [self._csv_row()])
+        # Set mtime to 23 hours ago — should NOT warn
+        os.utime(export, (time.time() - 23 * 3600, time.time() - 23 * 3600))
+        with caplog.at_level(logging.WARNING, logger="collectors.linkedin"):
+            collect_linkedin(linkedin_drops_dir=tmp_path)
+        assert not any("days old" in r.message for r in caplog.records)
+
+    def test_file_over_24h_logs_stale_warning(self, tmp_path, caplog):
+        import logging, os
+        export = tmp_path / "export.csv"
+        self._write_csv(export, [self._csv_row()])
+        # Set mtime to 25 hours ago — should warn
+        os.utime(export, (time.time() - 25 * 3600, time.time() - 25 * 3600))
+        with caplog.at_level(logging.WARNING, logger="collectors.linkedin"):
+            collect_linkedin(linkedin_drops_dir=tmp_path)
+        assert any("days old" in r.message for r in caplog.records)
+
     def test_stale_file_logs_warning(self, tmp_path, caplog):
         import logging
         import os
@@ -523,6 +543,28 @@ class TestCollectSubstack:
         with caplog.at_level(logging.WARNING, logger="collectors.substack"):
             collect_substack(substack_drops_dir=tmp_path)
         assert any("days old" in r.message for r in caplog.records)
+
+    def test_file_under_24h_no_stale_warning(self, tmp_path, caplog):
+        import logging, os
+        from collect import collect_substack
+        export = tmp_path / "export.csv"
+        self._write_csv(export, [self._csv_row()])
+        # 23 hours old — should NOT warn
+        os.utime(export, (time.time() - 23 * 3600, time.time() - 23 * 3600))
+        with caplog.at_level(logging.WARNING, logger="collectors.substack"):
+            collect_substack(substack_drops_dir=tmp_path)
+        assert not any("hours" in r.message for r in caplog.records)
+
+    def test_file_over_24h_logs_stale_warning(self, tmp_path, caplog):
+        import logging, os
+        from collect import collect_substack
+        export = tmp_path / "export.csv"
+        self._write_csv(export, [self._csv_row()])
+        # 25 hours old — should warn
+        os.utime(export, (time.time() - 25 * 3600, time.time() - 25 * 3600))
+        with caplog.at_level(logging.WARNING, logger="collectors.substack"):
+            collect_substack(substack_drops_dir=tmp_path)
+        assert any("hours" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -665,6 +707,34 @@ class TestCollectOreilly:
         items = result["payments"][0]["line_items"]
         assert len(items) == 1
         assert items[0]["amount_withheld"] == pytest.approx(25.0)
+
+    def test_recent_payment_no_staleness_warning(self, tmp_path, caplog):
+        """Payment < 25 days ago — no warning about new statement."""
+        import logging
+        from unittest.mock import patch
+        from datetime import datetime, timezone
+        from collect import collect_oreilly
+        # Fix "now" to 2026-03-20; payment on 2026-03-10 = 10 days ago → no warn
+        fixed_now = datetime(2026, 3, 20, tzinfo=timezone.utc)
+        _write_oreilly_eml(tmp_path / "payment.eml", payment_date="Mar 10, 2026")
+        with patch("collectors.oreilly._utcnow", return_value=fixed_now):
+            with caplog.at_level(logging.WARNING, logger="collectors.oreilly"):
+                collect_oreilly(oreilly_drops_dir=tmp_path)
+        assert not any("days ago" in r.message for r in caplog.records)
+
+    def test_old_payment_logs_staleness_warning(self, tmp_path, caplog):
+        """Payment ≥ 25 days ago — warn about checking email for new statement."""
+        import logging
+        from unittest.mock import patch
+        from datetime import datetime, timezone
+        from collect import collect_oreilly
+        # Fix "now" to 2026-03-20; payment on 2026-01-15 = 64 days ago → warn
+        fixed_now = datetime(2026, 3, 20, tzinfo=timezone.utc)
+        _write_oreilly_eml(tmp_path / "payment.eml", payment_date="Jan 15, 2026")
+        with patch("collectors.oreilly._utcnow", return_value=fixed_now):
+            with caplog.at_level(logging.WARNING, logger="collectors.oreilly"):
+                collect_oreilly(oreilly_drops_dir=tmp_path)
+        assert any("days ago" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -1296,6 +1366,47 @@ class TestCollectCalendly:
         result = collect_calendly("tok", since=SINCE)
         assert "lead_gen_bookings" not in result
         assert "lead_gen_event" not in result
+
+    def test_lead_gen_event_filters_total_bookings(self, respx_mock):
+        """When lead_gen_event is set, total_bookings counts only that event type."""
+        _calendly_mock(respx_mock)
+        active = [
+            {"event_type": ET_URI_INTRO},
+            {"event_type": ET_URI_INTRO},
+            {"event_type": ET_URI_CONSULT},  # different event — should be excluded
+        ]
+
+        def side_effect(request):
+            params = dict(request.url.params)
+            if params.get("status") == "active":
+                return httpx.Response(200, json={"collection": active})
+            return httpx.Response(200, json={"collection": []})
+
+        respx_mock.get("https://api.calendly.com/scheduled_events").mock(side_effect=side_effect)
+        result = collect_calendly("tok", since=SINCE, lead_gen_event="Intro call")
+        # total_bookings should only count the Intro call events, not the Consult
+        assert result["total_bookings"] == 2
+        assert result["lead_gen_bookings"] == 2
+        assert len(result["bookings_by_type"]) == 1
+        assert result["bookings_by_type"][0]["event_type"] == "Intro call"
+
+    def test_lead_gen_event_no_filter_without_setting(self, respx_mock):
+        """Without lead_gen_event, total_bookings counts all event types."""
+        _calendly_mock(respx_mock)
+        active = [
+            {"event_type": ET_URI_INTRO},
+            {"event_type": ET_URI_CONSULT},
+        ]
+
+        def side_effect(request):
+            params = dict(request.url.params)
+            if params.get("status") == "active":
+                return httpx.Response(200, json={"collection": active})
+            return httpx.Response(200, json={"collection": []})
+
+        respx_mock.get("https://api.calendly.com/scheduled_events").mock(side_effect=side_effect)
+        result = collect_calendly("tok", since=SINCE)
+        assert result["total_bookings"] == 2  # both event types counted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -490,3 +490,118 @@ class TestParseArgs:
         )
         assert set(action.choices) == set(PLATFORM_COLLECTORS.keys())
         assert len(action.choices) == len(PLATFORM_COLLECTORS)
+
+
+# ---------------------------------------------------------------------------
+# check_drop_staleness
+# ---------------------------------------------------------------------------
+
+class TestCheckDropStaleness:
+    def _write_csv(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("col\nval\n")
+        return path
+
+    def _write_eml(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("From: test@example.com\nSubject: Payment\n\nHello\n")
+        return path
+
+    def test_no_drops_returns_empty_list(self, tmp_path, monkeypatch):
+        """No files in any drop directory → no warnings."""
+        monkeypatch.chdir(tmp_path)
+        assert run.check_drop_staleness() == []
+
+    def test_recent_linkedin_csv_no_warning(self, tmp_path, monkeypatch):
+        """LinkedIn CSV < 24h old → no warning."""
+        monkeypatch.chdir(tmp_path)
+        self._write_csv(tmp_path / "linkedin_drops" / "export.csv")
+        warnings = run.check_drop_staleness()
+        assert not any("LinkedIn" in w for w in warnings)
+
+    def test_stale_linkedin_csv_warns(self, tmp_path, monkeypatch):
+        """LinkedIn CSV > 24h old → warning."""
+        monkeypatch.chdir(tmp_path)
+        export = tmp_path / "linkedin_drops" / "export.csv"
+        self._write_csv(export)
+        stale = time.time() - 25 * 3600
+        import os
+        os.utime(export, (stale, stale))
+        warnings = run.check_drop_staleness()
+        assert any("LinkedIn" in w for w in warnings)
+
+    def test_recent_substack_csv_no_warning(self, tmp_path, monkeypatch):
+        """Substack CSV < 24h old → no warning."""
+        monkeypatch.chdir(tmp_path)
+        self._write_csv(tmp_path / "substack_drops" / "export.csv")
+        warnings = run.check_drop_staleness()
+        assert not any("Substack" in w for w in warnings)
+
+    def test_stale_substack_csv_warns(self, tmp_path, monkeypatch):
+        """Substack CSV > 24h old → warning."""
+        monkeypatch.chdir(tmp_path)
+        export = tmp_path / "substack_drops" / "export.csv"
+        self._write_csv(export)
+        stale = time.time() - 25 * 3600
+        import os
+        os.utime(export, (stale, stale))
+        warnings = run.check_drop_staleness()
+        assert any("Substack" in w for w in warnings)
+
+    def test_no_drops_directory_no_warning(self, tmp_path, monkeypatch):
+        """Missing drop directories don't cause warnings."""
+        monkeypatch.chdir(tmp_path)
+        # Don't create any directories
+        assert run.check_drop_staleness() == []
+
+    def test_stale_oreilly_eml_warns(self, tmp_path, monkeypatch):
+        """O'Reilly .eml > 25 days old → warning."""
+        monkeypatch.chdir(tmp_path)
+        eml = tmp_path / "oreilly_drops" / "payment.eml"
+        self._write_eml(eml)
+        stale = time.time() - 26 * 24 * 3600
+        import os
+        os.utime(eml, (stale, stale))
+        warnings = run.check_drop_staleness()
+        assert any("O'Reilly" in w for w in warnings)
+
+    def test_recent_oreilly_eml_no_warning(self, tmp_path, monkeypatch):
+        """O'Reilly .eml < 25 days old → no warning."""
+        monkeypatch.chdir(tmp_path)
+        eml = tmp_path / "oreilly_drops" / "payment.eml"
+        self._write_eml(eml)
+        # 10 days old → no warn
+        recent = time.time() - 10 * 24 * 3600
+        import os
+        os.utime(eml, (recent, recent))
+        warnings = run.check_drop_staleness()
+        assert not any("O'Reilly" in w for w in warnings)
+
+    def test_multiple_stale_files_warn_for_each(self, tmp_path, monkeypatch):
+        """Multiple stale files → warning for each platform."""
+        monkeypatch.chdir(tmp_path)
+        stale_time = time.time() - 25 * 3600
+        import os
+
+        li = tmp_path / "linkedin_drops" / "li.csv"
+        self._write_csv(li)
+        os.utime(li, (stale_time, stale_time))
+
+        ss = tmp_path / "substack_drops" / "ss.csv"
+        self._write_csv(ss)
+        os.utime(ss, (stale_time, stale_time))
+
+        warnings = run.check_drop_staleness()
+        assert any("LinkedIn" in w for w in warnings)
+        assert any("Substack" in w for w in warnings)
+
+    def test_warning_includes_filename(self, tmp_path, monkeypatch):
+        """Warning message includes the stale filename."""
+        monkeypatch.chdir(tmp_path)
+        export = tmp_path / "linkedin_drops" / "my_export.csv"
+        self._write_csv(export)
+        stale = time.time() - 25 * 3600
+        import os
+        os.utime(export, (stale, stale))
+        warnings = run.check_drop_staleness()
+        assert any("my_export.csv" in w for w in warnings)


### PR DESCRIPTION
Summary: adds stale data warnings before collection (LinkedIn/Substack >24h, O'Reilly >25 days), filters Calendly counts to lead_gen_event only, and strengthens update.txt to prevent dashboard rebuild. 293 tests pass.