### PR TITLE
Fix dashboard: embed Dashboard.jsx instead of relying on GitHub URL fetch

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -254,11 +254,13 @@ def build_prompt(
     data_json = json.dumps(trimmed, indent=2, default=str)
     upcoming_section = _format_upcoming_section(collected_data)
 
-    # --- Assemble prompt ---
+    # --- Assemble prompt (Dashboard.jsx inserted as plain string to avoid brace
+    #     conflicts with Python's str.format) ---
     preamble = _read_preamble().format(
         period_window=period_window,
         period_id=period,
     )
+    dashboard_ref = _read_dashboard_reference()
     suffix = _read_suffix().format(
         period_id=period,
         period_window=period_window,
@@ -271,7 +273,7 @@ def build_prompt(
         data_json=data_json,
     )
 
-    return preamble + suffix
+    return preamble + dashboard_ref + suffix
 
 
 def build_update_prompt(

--- a/prompts/preamble.txt
+++ b/prompts/preamble.txt
@@ -61,7 +61,7 @@ Produce a single self-contained React component that renders the analytics dashb
 Rules:
 - Start with `import React, {{ useState }} from "react"` and `import {{ LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, ReferenceLine, Legend, Cell, ComposedChart }} from "recharts"` — recharts is available in artifacts.
 - Do NOT import from any external file. All data must be defined as constants at the top of the file (PERIOD_LABEL, STATS, blogDaily, linkedinDaily, mastodonPosts, vercelDaily, vercelReferrers, blogTopPosts, amazonBooks, newsletterIssues, funnelNorm, funnelInsights, calendlyByType, goatcounterEvents).
-- Model the structure, tabs, charts, colours, and styling exactly on the reference Dashboard.jsx at https://raw.githubusercontent.com/catehstn/social-brain/main/viz/Dashboard.jsx — fetch it and use it as your template. Export a default function named Dashboard.
+- Model the structure, tabs, charts, colours, and styling exactly on the reference Dashboard.jsx below. Export a default function named Dashboard.
 - Replace all placeholder values with real numbers from the JSON. Do not invent numbers. Use 0 or "n/a" for unavailable values.
 - Only include tabs for platforms that have data. Omit tabs entirely for missing platforms rather than showing empty sections.
 - blogDaily, linkedinDaily, vercelDaily: include all days in the period as {{d: "Mon DD", ...}} objects.
@@ -75,4 +75,5 @@ Rules:
 - If goatcounter data is present, include it in the Web tab — show total pageviews/unique visitors and a bar chart of top_paths. If events are present (e.g. quiz result distribution), add a small events breakdown chart. Define event data as goatcounterEvents.
 - When writing any text content into a JS double-quoted string literal, escape any double quotes in the content (replace " with \"). For example: `label: "She said \"hello\""`. This applies to post labels, titles, subjects, and any other text fields.
 
+Reference Dashboard.jsx:
 

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -574,11 +574,17 @@ class TestBuildPrompt:
             result = analyse.build_prompt({}, config, "2025-W23")
         assert "(none specified)" in result
 
-    def test_dashboard_github_url_in_preamble(self):
-        # The real preamble.txt must reference the public GitHub repo
+    def test_dashboard_reference_in_preamble(self):
+        # preamble.txt must include the "Reference Dashboard.jsx:" label that
+        # introduces the embedded dashboard content (not rely on a URL fetch)
         preamble = analyse.PREAMBLE_PATH.read_text()
-        assert "catehstn/social-brain" in preamble
-        assert "Dashboard.jsx" in preamble
+        assert "Reference Dashboard.jsx" in preamble
+
+    def test_dashboard_content_embedded_in_prompt(self, tmp_path):
+        # build_prompt must embed the dashboard content directly
+        with patch_templates(tmp_path):
+            result = analyse.build_prompt({}, self._base_config(), "2025-W23")
+        assert "// stub dashboard" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Claude cannot fetch raw GitHub URLs, so the instruction added in #14 to fetch Dashboard.jsx from github.com was silently failing — Claude rebuilt the dashboard from scratch on every run. This restores the embed approach and updates the test to match.