### PR TITLE
Smart run summary: only report platforms expected to have data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ substack_drops/*.csv
 
 # O'Reilly payment emails (contain financial/personal data)
 oreilly_drops/*.eml
+oreilly_drops/*.rtf
 
 # =============================================================================
 # Python

--- a/collectors/oreilly.py
+++ b/collectors/oreilly.py
@@ -134,21 +134,97 @@ def _parse_oreilly_eml(path: Path) -> dict[str, Any] | None:
     }
 
 
+def _parse_oreilly_rtf(path: Path) -> dict[str, Any] | None:
+    """
+    Parse a single O'Reilly Payment Remittance Advice .rtf file.
+    Strips RTF control words and extracts key fields via regex.
+    """
+    try:
+        with path.open("rb") as f:
+            raw = f.read().decode("latin-1", errors="replace")
+    except Exception as exc:
+        logger.warning("O'Reilly: could not read %s: %s", path.name, exc)
+        return None
+
+    # Strip RTF control words, braces, and backslashes to get plain text
+    text = re.sub(r"\\[a-z*]+[-]?\d* ?", " ", raw)
+    text = re.sub(r"[{}\\]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+
+    def _field(label: str, n_tokens: int = 1) -> str | None:
+        """Return the next n_tokens of plain text after label."""
+        m = re.search(re.escape(label) + r"\s+((?:\S+\s*){" + str(n_tokens) + r"})", text)
+        if m:
+            return m.group(1).strip()
+        return None
+
+    # Payment Date is 3 tokens: "Aug 29, 2025"
+    payment_date_str = _field("Payment Date", 3)
+    amount_str = _field("Payment Amount")
+    currency = _field("Payment Currency")
+    doc_number = _field("Paper Document Number")
+
+    if not payment_date_str or not amount_str:
+        logger.warning("O'Reilly: could not parse key fields from %s", path.name)
+        return None
+
+    # Normalise "Aug 29, 2025" (comma may be attached to day token)
+    payment_date_str = payment_date_str.replace(",", "").strip()
+    # Tokens: "Aug 29 2025" after stripping comma
+    try:
+        payment_date = datetime.strptime(payment_date_str, "%b %d %Y").strftime("%Y-%m-%d")
+        amount = float(amount_str.replace(",", ""))
+    except (ValueError, AttributeError) as exc:
+        logger.warning("O'Reilly: failed to parse values from %s: %s", path.name, exc)
+        return None
+
+    # Extract line items: doc-ref pattern followed by 6 more tokens
+    line_items = []
+    for m in re.finditer(r"([A-Z]+-\d+)\s+(\S+)\s+(ROYALTY\s+STATEMENT)\s+([\d.,]+)\s+([A-Z]{3})\s+([\d.,]+)\s+([\d.,]+)", text):
+        try:
+            doc_ref, doc_date, desc, doc_amt, cur, discount, amt_paid = m.groups()
+            line_items.append({
+                "doc_ref": doc_ref,
+                "doc_date": doc_date,
+                "description": desc.strip(),
+                "doc_amount": float(doc_amt.replace(",", "")),
+                "currency": cur,
+                "amount_withheld": 0.0,
+                "discount": float(discount.replace(",", "").lstrip(".") or "0"),
+                "amount_paid": float(amt_paid.replace(",", "")),
+            })
+        except (ValueError, AttributeError):
+            continue
+
+    return {
+        "payment_date": payment_date,
+        "doc_number": doc_number,
+        "amount": amount,
+        "currency": currency,
+        "line_items": line_items,
+        "source_file": path.name,
+    }
+
+
 def collect_oreilly(oreilly_drops_dir: str | Path = "oreilly_drops") -> dict[str, Any] | None:
     """
-    Parse all O'Reilly Payment Remittance Advice .eml files from
-    oreilly_drops/ and return the full payment history sorted by date.
+    Parse all O'Reilly Payment Remittance Advice files from oreilly_drops/.
+    Accepts both .eml (MIME email) and .rtf (Mail.app export) formats.
+    Returns the full payment history sorted by date.
     """
     drops_path = Path(oreilly_drops_dir)
-    eml_files = sorted(drops_path.glob("*.eml"), key=lambda p: p.stat().st_mtime)
+    all_files = sorted(
+        list(drops_path.glob("*.eml")) + list(drops_path.glob("*.rtf")),
+        key=lambda p: p.stat().st_mtime,
+    )
 
-    if not eml_files:
-        logger.info("O'Reilly: no .eml files found in %s — skipping", drops_path)
+    if not all_files:
+        logger.info("O'Reilly: no .eml or .rtf files found in %s — skipping", drops_path)
         return None
 
     payments = []
-    for path in eml_files:
-        parsed = _parse_oreilly_eml(path)
+    for path in all_files:
+        parsed = _parse_oreilly_rtf(path) if path.suffix == ".rtf" else _parse_oreilly_eml(path)
         if parsed:
             payments.append(parsed)
         else:

--- a/run.py
+++ b/run.py
@@ -142,10 +142,9 @@ def check_drop_staleness() -> list[str]:
                 files.extend(Path(".").glob(g))
         return max(files, key=lambda p: p.stat().st_mtime) if files else None
 
-    # LinkedIn and Substack: must be < 24 hours old
+    # LinkedIn: must be < 24 hours old
     for label, *globs in [
         ("LinkedIn", "linkedin_drops/*.csv", "linkedin_drops/*.xlsx"),
-        ("Substack", "substack_drops/*.csv"),
     ]:
         newest = _most_recent(*globs)
         if newest:
@@ -156,8 +155,8 @@ def check_drop_staleness() -> list[str]:
                     f"{label}: export '{newest.name}' is {hours:.0f}h old — download a fresh export first."
                 )
 
-    # O'Reilly: warn if most recent .eml is > 25 days old (monthly payment cycle)
-    newest_or = _most_recent("oreilly_drops/*.eml")
+    # O'Reilly: warn if most recent statement is > 25 days old (monthly payment cycle)
+    newest_or = _most_recent("oreilly_drops/*.eml", "oreilly_drops/*.rtf")
     if newest_or:
         age = now - datetime.fromtimestamp(newest_or.stat().st_mtime, tz=timezone.utc)
         if age > timedelta(days=25):
@@ -167,6 +166,146 @@ def check_drop_staleness() -> list[str]:
             )
 
     return warnings
+
+
+def _platform_expected(name: str, config: dict) -> bool:
+    """
+    Return True if a platform was expected to collect data — meaning it was
+    configured (API key/token present) or its file-drop directory has files.
+    Platforms that are neither configured nor have drop files are silently ignored.
+    """
+    def _has_files(*globs: str) -> bool:
+        for g in globs:
+            parts = g.rsplit("/", 1)
+            if len(parts) == 2:
+                base = Path(parts[0])
+                if base.exists() and any(base.glob(parts[1])):
+                    return True
+            elif any(Path(".").glob(g)):
+                return True
+        return False
+
+    if name == "mastodon":
+        return bool(config.get("mastodon_instance") and config.get("mastodon_handle"))
+    if name == "bluesky":
+        return bool(config.get("bluesky_handle"))
+    if name == "buttondown":
+        return bool(config.get("buttondown_api_key"))
+    if name == "jetpack":
+        return bool(config.get("jetpack_site") and config.get("jetpack_access_token"))
+    if name == "linkedin":
+        return _has_files("linkedin_drops/*.csv", "linkedin_drops/*.xlsx")
+    if name == "substack":
+        return _has_files("substack_drops/*.csv")
+    if name == "vercel":
+        return bool(config.get("vercel_token") and config.get("vercel_project_id"))
+    if name == "amazon":
+        return bool(config.get("amazon_asins"))
+    if name == "upcoming":
+        return bool(
+            (config.get("jetpack_site") and config.get("jetpack_access_token"))
+            or config.get("buttondown_api_key")
+            or config.get("buffer_token")
+        )
+    if name == "mentions":
+        return bool(config.get("monitored_domains"))
+    if name == "goatcounter":
+        return bool(config.get("goatcounter_site") and config.get("goatcounter_token"))
+    if name == "oreilly":
+        return _has_files("oreilly_drops/*.eml")
+    if name == "calendly":
+        return bool(config.get("calendly_token"))
+    return False
+
+
+def _platform_summary(name: str, data: dict) -> str:
+    """Return a brief one-line description of what was collected for a platform."""
+    try:
+        if name == "mastodon":
+            followers = data.get("account", {}).get("followers", "?")
+            posts = len(data.get("posts", []))
+            return f"{followers} followers, {posts} posts"
+        if name == "bluesky":
+            return f"{len(data.get('posts', []))} posts"
+        if name == "buttondown":
+            return f"{len(data.get('newsletters', []))} newsletter(s)"
+        if name == "jetpack":
+            return f"{data.get('total_views', '?')} views"
+        if name == "linkedin":
+            days = len(data.get("daily_engagement", []))
+            posts = len(data.get("top_posts_by_engagement", []))
+            return f"{days} days engagement, {posts} top posts"
+        if name == "substack":
+            return f"{len(data.get('emails', []))} emails"
+        if name == "vercel":
+            return f"{data.get('page_views', '?')} views"
+        if name == "amazon":
+            return f"{len(data.get('by_marketplace', {}))} marketplace(s)"
+        if name == "goatcounter":
+            return f"{data.get('total_pageviews', '?')} pageviews"
+        if name == "oreilly":
+            count = data.get("payment_count", 0)
+            total = data.get("total_paid", 0.0)
+            currencies = data.get("currencies") or ["?"]
+            return f"{count} payment(s), {currencies[0]} {total:.2f} total"
+        if name == "calendly":
+            bookings = data.get("total_bookings", 0)
+            lead = data.get("lead_gen_bookings")
+            if lead is not None:
+                return f"{bookings} booking(s) ({lead} lead gen)"
+            return f"{bookings} booking(s)"
+        if name == "mentions":
+            sources = data.get("sources", {})
+            hn = len(sources.get("hackernews", []))
+            mastodon = len(sources.get("mastodon", []))
+            bluesky = len(sources.get("bluesky", []))
+            return f"HN: {hn}, Mastodon: {mastodon}, Bluesky: {bluesky}"
+        if name == "upcoming":
+            sources = data.get("sources", {})
+            total = sum(len(v) for v in sources.values() if isinstance(v, list))
+            return f"{total} scheduled item(s)"
+    except Exception:
+        pass
+    return "ok"
+
+
+def _print_run_summary(
+    collected: dict,
+    all_platforms: list[str],
+    config: dict,
+    prompt_path: Path | None = None,
+    update: bool = False,
+) -> None:
+    """Print a clean end-of-run summary: what was collected and what wasn't."""
+    print("\n" + "=" * 52)
+    print("  Run complete")
+    print("=" * 52)
+
+    present = [p for p in all_platforms if p in collected]
+    # Only flag as "not collected" platforms that were actually expected to have data
+    missing = [
+        p for p in all_platforms
+        if p not in collected and _platform_expected(p, config)
+    ]
+
+    if present:
+        print("\nCollected:")
+        for p in present:
+            print(f"  ✓  {p:<14} {_platform_summary(p, collected[p])}")
+
+    if missing:
+        print("\nExpected but not collected:")
+        for p in missing:
+            print(f"  –  {p}")
+
+    if prompt_path:
+        action = "Paste into your existing claude.ai chat" if update else "Paste into claude.ai"
+        size_kb = f"{prompt_path.stat().st_size // 1024} KB" if prompt_path.exists() else ""
+        size_str = f" ({size_kb})" if size_kb else ""
+        print(f"\nPrompt{size_str}: {prompt_path}")
+        print(f"→  {action}")
+
+    print("=" * 52 + "\n")
 
 
 def since_last_run() -> datetime | None:
@@ -310,7 +449,8 @@ def main() -> None:
                 store_update(collected)
 
         if args.collect_only:
-            logger.info("--collect-only: done.")
+            from collectors import PLATFORM_COLLECTORS
+            _print_run_summary(collected, list(PLATFORM_COLLECTORS.keys()), config)
             return
 
     # ------------------------------------------------------------------
@@ -318,11 +458,6 @@ def main() -> None:
     # ------------------------------------------------------------------
     if args.analyse_only:
         collected, label = load_latest_raw()
-        logger.info(
-            "Loaded data from snapshot '%s' with platforms: %s",
-            label,
-            ", ".join(collected.keys()) if collected else "(empty)",
-        )
 
     if not collected:
         logger.warning(
@@ -331,12 +466,10 @@ def main() -> None:
 
     logger.info("=== Building analysis prompt ===")
     from analyse import save_prompt
+    from collectors import PLATFORM_COLLECTORS
 
     prompt_path = save_prompt(collected, config, period=label, reports_dir=REPORTS_DIR, months=args.months, update=args.update)
-    if args.update:
-        logger.info("=== Done. Paste %s into your existing claude.ai chat to update the report ===", prompt_path)
-    else:
-        logger.info("=== Done. Paste %s into claude.ai to get your report ===", prompt_path)
+    _print_run_summary(collected, list(PLATFORM_COLLECTORS.keys()), config, prompt_path=prompt_path, update=args.update)
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -212,7 +212,7 @@ def _platform_expected(name: str, config: dict) -> bool:
     if name == "goatcounter":
         return bool(config.get("goatcounter_site") and config.get("goatcounter_token"))
     if name == "oreilly":
-        return _has_files("oreilly_drops/*.eml")
+        return _has_files("oreilly_drops/*.eml", "oreilly_drops/*.rtf")
     if name == "calendly":
         return bool(config.get("calendly_token"))
     return False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -537,8 +537,8 @@ class TestCheckDropStaleness:
         warnings = run.check_drop_staleness()
         assert not any("Substack" in w for w in warnings)
 
-    def test_stale_substack_csv_warns(self, tmp_path, monkeypatch):
-        """Substack CSV > 24h old → warning."""
+    def test_stale_substack_csv_no_warning(self, tmp_path, monkeypatch):
+        """Substack CSV (even stale) → no warning — user doesn't use Substack."""
         monkeypatch.chdir(tmp_path)
         export = tmp_path / "substack_drops" / "export.csv"
         self._write_csv(export)
@@ -546,7 +546,7 @@ class TestCheckDropStaleness:
         import os
         os.utime(export, (stale, stale))
         warnings = run.check_drop_staleness()
-        assert any("Substack" in w for w in warnings)
+        assert not any("Substack" in w for w in warnings)
 
     def test_no_drops_directory_no_warning(self, tmp_path, monkeypatch):
         """Missing drop directories don't cause warnings."""
@@ -587,13 +587,8 @@ class TestCheckDropStaleness:
         self._write_csv(li)
         os.utime(li, (stale_time, stale_time))
 
-        ss = tmp_path / "substack_drops" / "ss.csv"
-        self._write_csv(ss)
-        os.utime(ss, (stale_time, stale_time))
-
         warnings = run.check_drop_staleness()
         assert any("LinkedIn" in w for w in warnings)
-        assert any("Substack" in w for w in warnings)
 
     def test_warning_includes_filename(self, tmp_path, monkeypatch):
         """Warning message includes the stale filename."""


### PR DESCRIPTION
Combines the work from PR #18 (run summary) and #20 (smart summary) into one clean PR on top of the current main.

## What changed

- **End-of-run summary**: After collection, prints a clean block showing each collected platform with key metrics (follower counts, post counts, views, etc.) and which expected platforms were not collected
- **Smart filtering**: Platforms are only flagged as "Expected but not collected" if they were actually configured (API key set) or have file drops present — unconfigured/unused platforms are silently omitted
- **RTF support for O'Reilly**: `oreilly_drops/` now accepts `.rtf` files (Mail.app export format) in addition to `.eml` — all 6 existing RTF files parse correctly
- **Staleness check updated**: O'Reilly staleness check covers both `.eml` and `.rtf`; Substack removed from staleness checks (not used)
- **Tests updated**: Substack staleness tests corrected to reflect that Substack files don't trigger warnings

## Tests

305 tests pass.

## Validation

Validated on real data: 6 O'Reilly RTF files parsed correctly ($1,190.89 total). Run summary prints cleanly at end of collection.