### PR TITLE
Fix TypeError when post text/content is None

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -90,7 +90,7 @@ def _trim_data(data: dict[str, Any], months: int | None = None) -> dict[str, Any
     # Mastodon: strip HTML, truncate, drop non-analytics fields, keep top 15 by engagement
     mastodon_posts = data.get("mastodon", {}).get("posts", [])
     for post in mastodon_posts:
-        post["content"] = _strip_html(post.get("content", ""))[:200]
+        post["content"] = _strip_html(post.get("content") or "")[:200]
         post.pop("id", None)
         post.pop("url", None)
     mastodon_posts.sort(
@@ -121,7 +121,7 @@ def _trim_data(data: dict[str, Any], months: int | None = None) -> dict[str, Any
         # Truncate post text and keep top 15 by engagement; drop impressions list (overlaps heavily)
         eng_posts = li.get("top_posts_by_engagement", [])
         for post in eng_posts:
-            post["text"] = _strip_html(post.get("text", ""))[:300]
+            post["text"] = _strip_html(post.get("text") or "")[:300]
             post.pop("url", None)
         li["top_posts_by_engagement"] = eng_posts[:linkedin_post_limit]
         li["top_posts_by_impressions_note"] = "Omitted — see top_posts_by_engagement for post content"

--- a/tests/test_analyse.py
+++ b/tests/test_analyse.py
@@ -179,6 +179,11 @@ class TestTrimData:
         result = analyse._trim_data(data)
         assert "note" in result["mastodon"]
 
+    def test_mastodon_none_content_does_not_crash(self):
+        data = {"mastodon": {"posts": [self._mastodon_post(content=None)]}}
+        result = analyse._trim_data(data)
+        assert result["mastodon"]["posts"][0]["content"] == ""
+
     # Bluesky
     def test_bluesky_truncates_text(self):
         data = {"bluesky": {"posts": [self._bluesky_post(text="y" * 300)]}}
@@ -363,6 +368,15 @@ class TestTrimDataLinkedIn:
         data = {"linkedin": {}}
         result = analyse._trim_data(data)
         assert "linkedin" in result
+
+    def test_none_post_text_does_not_crash(self):
+        data = {"linkedin": {
+            "top_posts_by_engagement": [{"text": None, "impressions": 10, "engagements": 1}],
+            "top_posts_by_impressions": [],
+            "daily_engagement": [],
+        }}
+        result = analyse._trim_data(data)
+        assert result["linkedin"]["top_posts_by_engagement"][0]["text"] == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `post.get("text", "")` returns `None` when the key exists but its value is `None` — the default only applies when the key is absent
- Switch to `post.get("text") or ""` in `_trim_data` for both LinkedIn `top_posts_by_engagement` and Mastodon `posts`
- Add regression tests for both platforms: `test_none_post_text_does_not_crash` and `test_mastodon_none_content_does_not_crash`

## Test plan
- [x] New tests pass
- [x] Full test suite passes (307 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)