### PR TITLE
Fix GoatCounter collector: date format, event detection, field names

### DIFF
--- a/collectors/goatcounter.py
+++ b/collectors/goatcounter.py
@@ -25,36 +25,45 @@ def collect_goatcounter(
 
     base = f"https://{site}.goatcounter.com/api/v0"
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    start = since.strftime("%Y-%m-%d")
-    end = _utcnow().strftime("%Y-%m-%d")
+    now = _utcnow()
+    # API expects date-time rounded to the hour
+    start = since.strftime("%Y-%m-%dT00:00:00Z")
+    end = now.strftime("%Y-%m-%dT%H:00:00Z")
+    # Keep plain dates for the result metadata
+    start_date = since.strftime("%Y-%m-%d")
+    end_date = now.strftime("%Y-%m-%d")
 
     try:
         with httpx.Client(timeout=30, headers=headers) as client:
             r = client.get(f"{base}/stats/total", params={"start": start, "end": end})
-            r.raise_for_status()
+            if not r.is_success:
+                logger.error("GoatCounter stats/total failed: HTTP %s — %s", r.status_code, r.text[:300])
+                return None
             total_data = r.json()
 
             r = client.get(f"{base}/stats/hits", params={"start": start, "end": end, "limit": 200})
-            r.raise_for_status()
+            if not r.is_success:
+                logger.error("GoatCounter stats/hits failed: HTTP %s — %s", r.status_code, r.text[:300])
+                return None
             hits_data = r.json()
 
         hits = hits_data.get("hits", [])
         top_paths = [
             {"path": h["path"], "count": h["count"]}
-            for h in hits if h["path"].startswith("/")
+            for h in hits if not h.get("event", False)
         ]
         events = [
             {"event": h["path"], "count": h["count"]}
-            for h in hits if not h["path"].startswith("/")
+            for h in hits if h.get("event", False)
         ]
 
         return {
             "platform": "goatcounter",
-            "collected_at": _iso(_utcnow()),
-            "period_start": start,
-            "period_end": end,
-            "total_pageviews": total_data.get("total", 0),
-            "total_unique": total_data.get("total_unique", 0),
+            "collected_at": _iso(now),
+            "period_start": start_date,
+            "period_end": end_date,
+            "total_visitors": total_data.get("total", 0),
+            "total_events": total_data.get("total_events", 0),
             "top_paths": top_paths,
             "events": events,
         }

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -854,14 +854,14 @@ class TestCollectGoatcounter:
 
     def _mock_all(self, respx_mock, hits=None, total=None):
         respx_mock.get(f"{self.BASE}/stats/total").mock(
-            return_value=httpx.Response(200, json=total or {"total": 1500, "total_unique": 900})
+            return_value=httpx.Response(200, json=total or {"total": 1500, "total_events": 200})
         )
         respx_mock.get(f"{self.BASE}/stats/hits").mock(
             return_value=httpx.Response(200, json={"hits": hits or [
-                {"path": "/", "count": 1300},
-                {"path": "/about", "count": 200},
-                {"path": "result/trike", "count": 120},
-                {"path": "result/mpr", "count": 80},
+                {"path": "/", "event": False, "count": 1300},
+                {"path": "/about", "event": False, "count": 200},
+                {"path": "result/trike", "event": True, "count": 120},
+                {"path": "result/mpr", "event": True, "count": 80},
             ]})
         )
 
@@ -870,8 +870,8 @@ class TestCollectGoatcounter:
         result = collect_goatcounter("what-raccoon", "token", since=SINCE)
         assert result is not None
         assert result["platform"] == "goatcounter"
-        assert result["total_pageviews"] == 1500
-        assert result["total_unique"] == 900
+        assert result["total_visitors"] == 1500
+        assert result["total_events"] == 200
 
     def test_page_paths_in_top_paths(self, respx_mock):
         self._mock_all(respx_mock)
@@ -894,7 +894,7 @@ class TestCollectGoatcounter:
         assert not any(p.startswith("result/") for p in paths)
 
     def test_no_events_returns_empty_list(self, respx_mock):
-        self._mock_all(respx_mock, hits=[{"path": "/", "count": 500}])
+        self._mock_all(respx_mock, hits=[{"path": "/", "event": False, "count": 500}])
         result = collect_goatcounter("what-raccoon", "token", since=SINCE)
         assert result["events"] == []
 


### PR DESCRIPTION
## What changed and why

The GoatCounter collector was silently returning no data due to several bugs:

- **Date format**: The API spec requires `date-time` format rounded to the hour (e.g. `2026-04-01T00:00:00Z`), but we were sending bare `YYYY-MM-DD` strings. A 400 response from this would be caught by the `except` block and silently return `None`.
- **Event detection**: Used `h["path"].startswith("/")` to tell events from page paths. The real GoatCounter API has an `event: bool` field on each `HitList` item — the code now uses that.
- **Bogus `total_unique` field**: `apiCountTotalResponse` has no `total_unique` field (it has `total`, `total_events`, `total_utc`). Was always returning 0. Fixed to use `total_visitors` and `total_events`.
- **Error logging**: Now logs `HTTP <status> — <body>` on API failures instead of just the exception message, so the actual cause is visible in logs.

## Tests

307/307 pass. Test mocks updated to use the `event` boolean field and corrected field names.

## Validation

Changes are narrowly scoped to the collector and its tests. No real-data run performed (requires live credentials), but the fixes align with the GoatCounter OpenAPI spec.