### PR TITLE
Collector improvements: Buttondown tags, Vercel top 50, Jetpack reauth, platform run fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Your site must have Jetpack active with Stats enabled.
    ```
 3. Set `jetpack_access_token` and `jetpack_site` (e.g. `yourdomain.com`) in `config.yaml`
 
+**Automatic token refresh (recommended):** If the token expires you'll get a 403. To handle this automatically, also set `jetpack_client_id`, `jetpack_client_secret`, and `jetpack_username` in `config.yaml`. When a 403 is detected, the script will prompt for your WordPress.com password at the terminal (never stored), re-auth, save the new token, and retry — no manual curl needed.
+
 Collects: daily page views, top posts, referrer sources, email subscriber count, WordPress.com follower count, and scheduled future posts.
 
 **Google Search Console**

--- a/collectors/_dispatch.py
+++ b/collectors/_dispatch.py
@@ -84,7 +84,12 @@ def collect_all(
             if not jetpack_site or not jetpack_token:
                 logger.info("Jetpack: jetpack_site or jetpack_access_token not configured — skipping")
                 return
-            data = collect_jetpack(jetpack_site, jetpack_token, since=since)
+            data = collect_jetpack(
+                jetpack_site, jetpack_token, since=since,
+                client_id=config.get("jetpack_client_id", ""),
+                client_secret=config.get("jetpack_client_secret", ""),
+                username=config.get("jetpack_username", ""),
+            )
         elif name == "linkedin":
             data = collect_linkedin()
         elif name == "substack":

--- a/collectors/buttondown.py
+++ b/collectors/buttondown.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import httpx
 
-from collectors._helpers import _utcnow, _iso
+from collectors._helpers import _utcnow, _iso, _default_since
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +17,12 @@ def _collect_buttondown_newsletter(
     newsletter_key: str,
     since: datetime | None,
     use_since: bool,
-) -> tuple[list[dict], int | None]:
-    """Collect emails and subscriber count for a single Buttondown newsletter."""
+) -> tuple[list[dict], int | None, dict[str, int], dict[str, int]]:
+    """Collect emails and subscriber data for a single Buttondown newsletter.
+
+    Returns (emails, total_subscriber_count, tag_totals, tag_new_since).
+    tag_totals and tag_new_since are empty dicts for newsletters with no tags.
+    """
     headers = {"Authorization": f"Token {newsletter_key}"}
     newsletters: list[dict] = []
     page = 1
@@ -80,15 +84,55 @@ def _collect_buttondown_newsletter(
             break
         page += 1
 
-    sr = client.get(
-        "https://api.buttondown.email/v1/subscribers",
-        params={"page_size": 1},
-        headers=headers,
-    )
-    sr.raise_for_status()
-    subscriber_count = sr.json().get("count", None)
+    # Check if this newsletter has any tags before paginating all subscribers
+    tags_r = client.get("https://api.buttondown.email/v1/tags", headers=headers)
+    tags_r.raise_for_status()
+    has_tags = tags_r.json().get("count", 0) > 0
 
-    return newsletters, subscriber_count
+    tag_totals: dict[str, int] = {}
+    tag_new: dict[str, int] = {}
+    subscriber_count: int | None = None
+
+    if has_tags:
+        # Paginate all subscribers and count by tag client-side
+        # (API tag filter doesn't work server-side)
+        sub_page = 1
+        while True:
+            sr = client.get(
+                "https://api.buttondown.email/v1/subscribers",
+                params={"page_size": 100, "page": sub_page},
+                headers=headers,
+            )
+            sr.raise_for_status()
+            sub_data = sr.json()
+            if subscriber_count is None:
+                subscriber_count = sub_data.get("count")
+            for sub in sub_data.get("results", []):
+                for tag in sub.get("tags", []):
+                    tag_totals[tag] = tag_totals.get(tag, 0) + 1
+                    count_since = since or _default_since()
+                    if sub.get("creation_date"):
+                        try:
+                            created = datetime.fromisoformat(
+                                sub["creation_date"].replace("Z", "+00:00")
+                            )
+                            if created >= count_since:
+                                tag_new[tag] = tag_new.get(tag, 0) + 1
+                        except ValueError:
+                            pass
+            if not sub_data.get("next"):
+                break
+            sub_page += 1
+    else:
+        sr = client.get(
+            "https://api.buttondown.email/v1/subscribers",
+            params={"page_size": 1},
+            headers=headers,
+        )
+        sr.raise_for_status()
+        subscriber_count = sr.json().get("count", None)
+
+    return newsletters, subscriber_count, tag_totals, tag_new
 
 
 def collect_buttondown(
@@ -106,6 +150,8 @@ def collect_buttondown(
     try:
         all_newsletters: list[dict] = []
         subscriber_counts: dict[str, int] = {}
+        tag_counts: dict[str, dict[str, int]] = {}
+        tag_new_counts: dict[str, dict[str, int]] = {}
 
         with httpx.Client(timeout=30) as client:
             # Discover all newsletters on the account
@@ -120,15 +166,19 @@ def collect_buttondown(
                 nl_name = nl.get("name", nl.get("domain", nl["id"]))
                 nl_key = nl.get("api_key", api_key)
                 try:
-                    emails, count = _collect_buttondown_newsletter(
+                    emails, count, tag_totals, tag_new = _collect_buttondown_newsletter(
                         client, nl_name, nl_key, since, use_since
                     )
                     all_newsletters.extend(emails)
                     if count is not None:
                         subscriber_counts[nl_name] = count
+                    if tag_totals:
+                        tag_counts[nl_name] = tag_totals
+                    if tag_new:
+                        tag_new_counts[nl_name] = tag_new
                     logger.info(
-                        "Buttondown [%s]: %d newsletters, %s subscribers",
-                        nl_name, len(emails), count,
+                        "Buttondown [%s]: %d emails, %s subscribers, %d tags",
+                        nl_name, len(emails), count, len(tag_totals),
                     )
                 except Exception as exc:
                     logger.warning("Buttondown [%s] failed: %s", nl_name, exc)
@@ -142,6 +192,10 @@ def collect_buttondown(
             "subscriber_counts": subscriber_counts,
             "newsletters": all_newsletters,
         }
+        if tag_counts:
+            result["subscriber_tags"] = tag_counts
+        if tag_new_counts:
+            result["new_subscribers_by_tag"] = tag_new_counts
         if use_since:
             result["since"] = _iso(since)
         return result

--- a/collectors/jetpack.py
+++ b/collectors/jetpack.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import getpass
 import logging
+import pathlib
+import re
 from datetime import datetime
 from typing import Any
 
@@ -10,39 +13,83 @@ from collectors._helpers import _utcnow, _iso, _default_since
 
 logger = logging.getLogger(__name__)
 
+_CONFIG_PATH = pathlib.Path(__file__).parent.parent / "config.yaml"
+
+
+def _reauth_jetpack(client_id: str, client_secret: str, username: str, password: str) -> str | None:
+    """Exchange WordPress.com credentials for a new access token. Returns token or None."""
+    try:
+        r = httpx.post(
+            "https://public-api.wordpress.com/oauth2/token",
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "password",
+                "username": username,
+                "password": password,
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        token = r.json().get("access_token")
+        if token:
+            logger.info("Jetpack: re-auth succeeded, saving new token to config.yaml")
+            _save_token_to_config(token)
+        return token
+    except Exception as exc:
+        logger.error("Jetpack re-auth failed: %s", exc)
+        return None
+
+
+def _save_token_to_config(new_token: str) -> None:
+    """Replace jetpack_access_token value in config.yaml in-place."""
+    try:
+        text = _CONFIG_PATH.read_text()
+        updated = re.sub(
+            r"(?m)^(\s*jetpack_access_token\s*:\s*).*$",
+            rf"\g<1>{new_token}",
+            text,
+        )
+        _CONFIG_PATH.write_text(updated)
+    except Exception as exc:
+        logger.warning("Jetpack: could not update config.yaml with new token: %s", exc)
+
 
 def collect_jetpack(
     site: str,
     access_token: str,
     since: datetime | None = None,
+    client_id: str = "",
+    client_secret: str = "",
+    username: str = "",
 ) -> dict[str, Any] | None:
     """
     Collect daily page views and top posts from Jetpack Stats back to `since`
     (default: 2 weeks ago).
+
+    If client_id, client_secret, and username are configured, a 403 response
+    will prompt for the WordPress.com password at the terminal, re-auth, save
+    the new token to config.yaml, and retry automatically.
     """
     if since is None:
         since = _default_since()
 
-    try:
-        headers = {"Authorization": f"Bearer {access_token}"}
-        base = f"https://public-api.wordpress.com/rest/v1.1/sites/{site}/stats"
+    can_reauth = all([client_id, client_secret, username])
 
+    def _fetch(token: str) -> dict[str, Any]:
+        headers = {"Authorization": f"Bearer {token}"}
+        base = f"https://public-api.wordpress.com/rest/v1.1/sites/{site}/stats"
         today = _utcnow().date()
         quantity = (today - since.date()).days + 1
 
         with httpx.Client(timeout=30, headers=headers) as client:
             r = client.get(
                 f"{base}/visits",
-                params={
-                    "unit": "day",
-                    "quantity": quantity,
-                    "date": today.isoformat(),
-                },
+                params={"unit": "day", "quantity": quantity, "date": today.isoformat()},
             )
             r.raise_for_status()
             visits_data = r.json()
 
-            # For longer periods use "month" period for top posts to get a broader view
             top_posts_period = "month" if quantity > 30 else "week"
             tp = client.get(
                 f"{base}/top-posts",
@@ -58,26 +105,16 @@ def collect_jetpack(
 
             rr = client.get(
                 f"{base}/referrers",
-                params={
-                    "period": "day",
-                    "num": quantity,
-                    "date": today.isoformat(),
-                },
+                params={"period": "day", "num": quantity, "date": today.isoformat()},
             )
             rr.raise_for_status()
             referrers_data = rr.json()
 
-            fe = client.get(
-                f"{base}/followers",
-                params={"type": "email", "max": 0},
-            )
+            fe = client.get(f"{base}/followers", params={"type": "email", "max": 0})
             fe.raise_for_status()
             email_followers_data = fe.json()
 
-            fw = client.get(
-                f"{base}/followers",
-                params={"type": "wpcom", "max": 0},
-            )
+            fw = client.get(f"{base}/followers", params={"type": "wpcom", "max": 0})
             fw.raise_for_status()
             wpcom_followers_data = fw.json()
 
@@ -86,10 +123,7 @@ def collect_jetpack(
             if isinstance(row, list) and len(row) >= 2:
                 daily_views.append({"date": row[0], "views": row[1]})
 
-        # The API returns either a flat "top-posts" list or a "days" dict
-        # with per-day postviews arrays — handle both and aggregate.
         top_posts_raw: dict[str, dict] = {}
-
         if "top-posts" in top_posts_data:
             for post in top_posts_data["top-posts"]:
                 href = post.get("href", "")
@@ -113,9 +147,7 @@ def collect_jetpack(
                             "views": post.get("views", 0),
                         }
 
-        top_posts = sorted(
-            top_posts_raw.values(), key=lambda p: p["views"], reverse=True
-        )[:10]
+        top_posts = sorted(top_posts_raw.values(), key=lambda p: p["views"], reverse=True)[:10]
 
         referrers_raw: dict[str, int] = {}
         for day_data in referrers_data.get("days", {}).values():
@@ -130,15 +162,11 @@ def collect_jetpack(
 
         email_subscribers = email_followers_data.get("total", 0)
         wpcom_followers = wpcom_followers_data.get("total", 0)
-
         total_views = sum(d["views"] for d in daily_views)
+
         logger.info(
             "Jetpack: collected %d days of data (%d total views, %d referrers, %d email subs, %d wpcom followers)",
-            len(daily_views),
-            total_views,
-            len(referrers),
-            email_subscribers,
-            wpcom_followers,
+            len(daily_views), total_views, len(referrers), email_subscribers, wpcom_followers,
         )
         return {
             "platform": "jetpack",
@@ -153,6 +181,21 @@ def collect_jetpack(
             "wpcom_followers": wpcom_followers,
         }
 
+    try:
+        return _fetch(access_token)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 403 and can_reauth:
+            logger.warning("Jetpack: 403 — token expired, prompting for WordPress.com password")
+            password = getpass.getpass(f"WordPress.com password for {username}: ")
+            new_token = _reauth_jetpack(client_id, client_secret, username, password)
+            if new_token:
+                try:
+                    return _fetch(new_token)
+                except Exception as retry_exc:
+                    logger.error("Jetpack collection failed after re-auth: %s", retry_exc)
+                    return None
+        logger.error("Jetpack collection failed: %s", exc)
+        return None
     except Exception as exc:
         logger.error("Jetpack collection failed: %s", exc)
         return None

--- a/collectors/vercel.py
+++ b/collectors/vercel.py
@@ -50,7 +50,7 @@ def collect_vercel(
             ts_r.raise_for_status()
             timeseries = ts_r.json()
 
-            pages_r = client.get(f"{base}/stats", params={**common_params, "type": "path", "limit": 20})
+            pages_r = client.get(f"{base}/stats", params={**common_params, "type": "path", "limit": 50})
             pages_r.raise_for_status()
             pages_data = pages_r.json()
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,11 @@ buttondown_api_key: YOUR_BUTTONDOWN_API_KEY
 # --- Jetpack / WordPress.com Stats ---
 jetpack_site: yourdomain.com           # your WordPress site domain
 jetpack_access_token: YOUR_JETPACK_ACCESS_TOKEN
+# Optional: if set, a 403 (expired token) will prompt for your password at runtime,
+# re-auth automatically, and save the new token back to this file.
+# jetpack_client_id: YOUR_CLIENT_ID
+# jetpack_client_secret: YOUR_CLIENT_SECRET
+# jetpack_username: your-wordpress-username   # username, not email
 
 # --- Amazon (public product pages, no auth required) ---
 amazon_asins:

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -241,6 +241,8 @@ class TestCollectBluesky:
 # ---------------------------------------------------------------------------
 
 class TestCollectButtondown:
+    NO_TAGS = httpx.Response(200, json={"results": [], "count": 0, "next": None})
+
     def _newsletter(self, nl_id: str = "nl1", name: str = "my-newsletter", api_key: str = "key123") -> dict:
         return {"id": nl_id, "name": name, "api_key": api_key}
 
@@ -260,6 +262,7 @@ class TestCollectButtondown:
                 "results": [self._email("e1", "Issue 1", RECENT)], "next": None,
             })
         )
+        respx_mock.get("https://api.buttondown.email/v1/tags").mock(return_value=self.NO_TAGS)
         respx_mock.get("https://api.buttondown.email/v1/subscribers").mock(
             return_value=httpx.Response(200, json={"count": 520})
         )
@@ -278,6 +281,7 @@ class TestCollectButtondown:
                 "results": [self._email("e1", "Issue 1", RECENT)], "next": None,
             })
         )
+        respx_mock.get("https://api.buttondown.email/v1/tags").mock(return_value=self.NO_TAGS)
         respx_mock.get("https://api.buttondown.email/v1/subscribers").mock(
             return_value=httpx.Response(200, json={"count": 500})
         )
@@ -293,6 +297,7 @@ class TestCollectButtondown:
         respx_mock.get("https://api.buttondown.email/v1/emails").mock(
             return_value=httpx.Response(200, json={"results": [], "next": None})
         )
+        respx_mock.get("https://api.buttondown.email/v1/tags").mock(return_value=self.NO_TAGS)
         respx_mock.get("https://api.buttondown.email/v1/subscribers").mock(
             return_value=httpx.Response(200, json={"count": 750})
         )
@@ -327,12 +332,51 @@ class TestCollectButtondown:
                 "next": None,
             })
         )
+        respx_mock.get("https://api.buttondown.email/v1/tags").mock(return_value=self.NO_TAGS)
         respx_mock.get("https://api.buttondown.email/v1/subscribers").mock(
             return_value=httpx.Response(200, json={"count": 500})
         )
         result = collect_buttondown("apikey", since=SINCE)
         assert len(result["newsletters"]) == 1
         assert result["newsletters"][0]["id"] == "e1"
+
+    def test_tag_counts_returned_when_tags_exist(self, respx_mock):
+        respx_mock.get("https://api.buttondown.email/v1/newsletters").mock(
+            return_value=httpx.Response(200, json={"results": [self._newsletter()]})
+        )
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None})
+        )
+        respx_mock.get("https://api.buttondown.email/v1/tags").mock(
+            return_value=httpx.Response(200, json={"results": [{"name": "cohort-1"}], "count": 1})
+        )
+        respx_mock.get("https://api.buttondown.email/v1/subscribers").mock(
+            return_value=httpx.Response(200, json={
+                "count": 2, "next": None, "results": [
+                    {"tags": ["cohort-1"], "creation_date": RECENT},
+                    {"tags": ["cohort-1"], "creation_date": OLD},
+                ]
+            })
+        )
+        result = collect_buttondown("apikey", since=SINCE)
+        assert result["subscriber_tags"]["my-newsletter"] == {"cohort-1": 2}
+        # Only RECENT subscriber is within since window
+        assert result["new_subscribers_by_tag"]["my-newsletter"] == {"cohort-1": 1}
+
+    def test_no_tags_omits_tag_fields(self, respx_mock):
+        respx_mock.get("https://api.buttondown.email/v1/newsletters").mock(
+            return_value=httpx.Response(200, json={"results": [self._newsletter()]})
+        )
+        respx_mock.get("https://api.buttondown.email/v1/emails").mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None})
+        )
+        respx_mock.get("https://api.buttondown.email/v1/tags").mock(return_value=self.NO_TAGS)
+        respx_mock.get("https://api.buttondown.email/v1/subscribers").mock(
+            return_value=httpx.Response(200, json={"count": 100})
+        )
+        result = collect_buttondown("apikey", since=SINCE)
+        assert "subscriber_tags" not in result
+        assert "new_subscribers_by_tag" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed and why

**Buttondown: subscriber segmentation by tag**
The subscriber count was a single total per newsletter. DRI Your Career uses tags to track cohort membership. Now the collector paginates all subscribers for tagged newsletters and counts by tag — both total and new within the since window. The Buttondown API tag filter is broken server-side (always returns all subscribers regardless of filter), so this is done client-side.

**Vercel: top pages limit 20 → 50**
/purchase-success was at position 27 and being silently dropped from every report. 3 purchases were not visible in the data at all. Bumped to 50.

**Jetpack: automatic token refresh on 403**
If jetpack_client_id, jetpack_client_secret, and jetpack_username are set in config, a 403 now prompts for the WordPress.com password via getpass (never stored), re-auths with scope=auth, saves the new token to config.yaml in-place, and retries. The fresh token is propagated in-memory so the upcoming collector doesn't trigger a second prompt.

**--platform runs: fix overwrite + add easy-grab output**
`--platform jetpack` previously overwrote the full weekly snapshot with just the one platform's data, so the generated prompt was missing everything else. Now single-platform data is saved to `data/platform/{name}-latest.json` and the prompt is built by merging the fresh data into the existing full snapshot.

**--platform runs: hide irrelevant 'Expected but not collected' noise**
When running a single platform, the summary no longer lists every other configured platform as missing.

## Tests

309/309 pass. New tests: test_tag_counts_returned_when_tags_exist, test_no_tags_omits_tag_fields.

## Validation

All changes validated against live APIs in this session.