### PR TITLE
Merge per-post impressions into engagement list

### DIFF
--- a/collectors/linkedin.py
+++ b/collectors/linkedin.py
@@ -142,8 +142,12 @@ def _parse_linkedin_xlsx(path: Path) -> dict[str, Any]:
             post_texts[post_url] = text
             logger.debug("LinkedIn post text fetched: %s chars", len(text) if text else 0)
 
+        # Build impressions lookup from the right-side table
+        impressions_by_url = {p["url"]: p["impressions"] for p in top_by_impressions}
+
         for p in top_by_engagement:
             p["text"] = post_texts.get(p["url"])
+            p["impressions"] = impressions_by_url.get(p["url"])
         for p in top_by_impressions:
             p["text"] = post_texts.get(p["url"])
 


### PR DESCRIPTION
## Summary
- Per-post impressions from the LinkedIn XLSX TOP POSTS sheet were being parsed into a separate list but not merged into the engagement list
- Now each post in `top_posts_by_engagement` includes its `impressions` value, enabling per-post engagement rate calculation
- Example: AI influencer post shows 51 eng / 1,807 imp (2.8% rate)

## Test plan
- [x] All 309 tests pass
- [x] Validated on real data (Content_2026-04-25_2026-05-01_CateHuston.xlsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)