### PR TITLE
Fix issue #30: write per-platform latest snapshots on each collection run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ config.yaml
 # To share a specific snapshot, use: git add -f data/weekly/2025-W22.json
 data/weekly/*.json
 
+# Per-platform latest snapshots — updated on each collection run.
+data/platform/*.json
+
 # Persistent analytics store — contains your full history, gitignored.
 data/analytics.xlsx
 

--- a/run.py
+++ b/run.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 ROOT = Path(__file__).parent
 CONFIG_PATH = ROOT / "config.yaml"
 DATA_DIR = ROOT / "data" / "weekly"
+PLATFORM_DIR = ROOT / "data" / "platform"
 REPORTS_DIR = ROOT / "reports"
 
 REQUIRED_CONFIG_KEYS = [
@@ -111,6 +112,16 @@ def save_raw(data: dict, label: str) -> Path:
         json.dump(data, f, indent=2, default=str)
     logger.info("Raw data saved → %s", path)
     return path
+
+
+def save_platform_latest(collected: dict) -> None:
+    """Write per-platform latest snapshots to data/platform/<name>-latest.json."""
+    PLATFORM_DIR.mkdir(parents=True, exist_ok=True)
+    for name, data in collected.items():
+        path = PLATFORM_DIR / f"{name}-latest.json"
+        with path.open("w") as f:
+            json.dump({name: data}, f, indent=2, default=str)
+    logger.info("Platform snapshots updated → %s", PLATFORM_DIR)
 
 
 def load_latest_raw() -> tuple[dict, str]:
@@ -523,6 +534,8 @@ def main() -> None:
             )
 
         save_raw(collected, label)
+        if collected:
+            save_platform_latest(collected)
 
         # ------------------------------------------------------------------
         # Persistent store — upsert into analytics.xlsx

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -155,6 +155,54 @@ class TestSaveRaw:
 
 
 # ---------------------------------------------------------------------------
+# save_platform_latest
+# ---------------------------------------------------------------------------
+
+class TestSavePlatformLatest:
+    def test_creates_directory_if_absent(self, tmp_path, monkeypatch):
+        platform_dir = tmp_path / "data" / "platform"
+        monkeypatch.setattr(run, "PLATFORM_DIR", platform_dir)
+        assert not platform_dir.exists()
+        run.save_platform_latest({"buttondown": {"collected_at": "2026-05-29"}})
+        assert platform_dir.exists()
+
+    def test_writes_one_file_per_platform(self, tmp_path, monkeypatch):
+        platform_dir = tmp_path / "data" / "platform"
+        monkeypatch.setattr(run, "PLATFORM_DIR", platform_dir)
+        run.save_platform_latest({
+            "buttondown": {"collected_at": "2026-05-29"},
+            "mastodon": {"posts": []},
+        })
+        assert (platform_dir / "buttondown-latest.json").exists()
+        assert (platform_dir / "mastodon-latest.json").exists()
+
+    def test_file_wrapped_in_platform_key(self, tmp_path, monkeypatch):
+        platform_dir = tmp_path / "data" / "platform"
+        monkeypatch.setattr(run, "PLATFORM_DIR", platform_dir)
+        run.save_platform_latest({"buttondown": {"collected_at": "2026-05-29", "newsletters": []}})
+        data = json.loads((platform_dir / "buttondown-latest.json").read_text())
+        assert "buttondown" in data
+        assert data["buttondown"]["collected_at"] == "2026-05-29"
+
+    def test_overwrites_existing_file(self, tmp_path, monkeypatch):
+        platform_dir = tmp_path / "data" / "platform"
+        platform_dir.mkdir(parents=True)
+        monkeypatch.setattr(run, "PLATFORM_DIR", platform_dir)
+        old = platform_dir / "buttondown-latest.json"
+        old.write_text(json.dumps({"buttondown": {"collected_at": "2026-04-24"}}))
+        run.save_platform_latest({"buttondown": {"collected_at": "2026-05-29"}})
+        data = json.loads(old.read_text())
+        assert data["buttondown"]["collected_at"] == "2026-05-29"
+
+    def test_empty_collected_writes_nothing(self, tmp_path, monkeypatch):
+        platform_dir = tmp_path / "data" / "platform"
+        monkeypatch.setattr(run, "PLATFORM_DIR", platform_dir)
+        run.save_platform_latest({})
+        assert platform_dir.exists()
+        assert list(platform_dir.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
 # load_latest_raw
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What changed and why

`data/platform/<name>-latest.json` files existed on disk but were never written by any code — they were stale artifacts from a previous setup. This caused `data/platform/buttondown-latest.json` to show `collected_at: 2026-04-24` even after Buttondown was re-collected, leading to false "overdue newsletter" flags in strategy reviews.

**Fix:** added `save_platform_latest(collected)` in `run.py` which writes one JSON file per platform to `data/platform/` immediately after each collection run. The file wraps the platform data in its platform key (same format as the weekly snapshot but single-platform).

Also gitignores `data/platform/*.json` alongside the existing `data/weekly/*.json` rule.

## Tests pass

317 passed (5 new tests covering: directory creation, one-file-per-platform, correct wrapping, overwrite behaviour, empty-collected no-op).

## Validation

The fix can be verified by running `python3 run.py --collect-only` and confirming `data/platform/buttondown-latest.json` now reflects today's `collected_at`.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)