### PR TITLE
Improve GoatCounter error logging and defensive null handling

### DIFF
--- a/collectors/goatcounter.py
+++ b/collectors/goatcounter.py
@@ -37,17 +37,23 @@ def collect_goatcounter(
         with httpx.Client(timeout=30, headers=headers) as client:
             r = client.get(f"{base}/stats/total", params={"start": start, "end": end})
             if not r.is_success:
-                logger.error("GoatCounter stats/total failed: HTTP %s — %s", r.status_code, r.text[:300])
+                logger.error(
+                    "GoatCounter stats/total failed: HTTP %s — %s",
+                    r.status_code, r.text[:300],
+                )
                 return None
             total_data = r.json()
 
             r = client.get(f"{base}/stats/hits", params={"start": start, "end": end, "limit": 200})
             if not r.is_success:
-                logger.error("GoatCounter stats/hits failed: HTTP %s — %s", r.status_code, r.text[:300])
+                logger.error(
+                    "GoatCounter stats/hits failed: HTTP %s — %s",
+                    r.status_code, r.text[:300],
+                )
                 return None
             hits_data = r.json()
 
-        hits = hits_data.get("hits", [])
+        hits = hits_data.get("hits") or []
         top_paths = [
             {"path": h["path"], "count": h["count"]}
             for h in hits if not h.get("event", False)
@@ -67,6 +73,12 @@ def collect_goatcounter(
             "top_paths": top_paths,
             "events": events,
         }
+    except httpx.TimeoutException as exc:
+        logger.error("GoatCounter collection timed out (%s): %s", type(exc).__name__, exc)
+        return None
+    except httpx.HTTPError as exc:
+        logger.error("GoatCounter HTTP error (%s): %s", type(exc).__name__, exc)
+        return None
     except Exception as exc:
-        logger.error("GoatCounter collection failed: %s", exc)
+        logger.error("GoatCounter collection failed (%s): %s", type(exc).__name__, exc)
         return None

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -955,6 +955,38 @@ class TestCollectGoatcounter:
         result = collect_goatcounter("what-raccoon", "token", since=SINCE)
         assert result["period_start"] == SINCE.strftime("%Y-%m-%d")
 
+    def test_null_hits_field_returns_empty_lists(self, respx_mock):
+        """API returning {"hits": null} is handled safely (not a TypeError)."""
+        respx_mock.get(f"{self.BASE}/stats/total").mock(
+            return_value=httpx.Response(200, json={"total": 5, "total_events": 0})
+        )
+        respx_mock.get(f"{self.BASE}/stats/hits").mock(
+            return_value=httpx.Response(200, json={"hits": None})
+        )
+        result = collect_goatcounter("what-raccoon", "token", since=SINCE)
+        assert result is not None
+        assert result["top_paths"] == []
+        assert result["events"] == []
+
+    def test_timeout_returns_none(self, respx_mock):
+        """A timeout is caught and returns None without crashing."""
+        respx_mock.get(f"{self.BASE}/stats/total").mock(
+            side_effect=httpx.TimeoutException("timed out")
+        )
+        result = collect_goatcounter("what-raccoon", "token", since=SINCE)
+        assert result is None
+
+    def test_hits_api_error_returns_none(self, respx_mock):
+        """Non-2xx on stats/hits (after stats/total succeeds) returns None."""
+        respx_mock.get(f"{self.BASE}/stats/total").mock(
+            return_value=httpx.Response(200, json={"total": 5, "total_events": 0})
+        )
+        respx_mock.get(f"{self.BASE}/stats/hits").mock(
+            return_value=httpx.Response(429, json={"error": "rate limited"})
+        )
+        result = collect_goatcounter("what-raccoon", "token", since=SINCE)
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # collect_mentions


### PR DESCRIPTION
## What changed and why

GoatCounter has been absent from 4 consecutive regular collection runs (W14, W17, W18, W21) while succeeding in backfill runs. Investigation ruled out code-level causes (same `since` window, API works today, response sizes scale normally). The collector's catch-all `except Exception` makes it impossible to tell from logs whether failures were rate limits, timeouts, or something else.

**Changes:**
- Split the generic `except Exception` into `TimeoutException`, `HTTPError`, and `Exception` handlers — each logs its class name so future failures are diagnosable
- Changed `hits_data.get("hits", [])` → `hits_data.get("hits") or []` to handle `{"hits": null}` without raising TypeError

**Tests:** 3 new tests (null hits field, timeout, hits-endpoint 429). All 347 pass.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)