### PR TITLE
Improve mastodon error handling: typed exceptions, don't lose posts on follows failure

### DIFF
--- a/collectors/mastodon.py
+++ b/collectors/mastodon.py
@@ -86,42 +86,48 @@ def collect_mastodon(
         # New follows during the period (requires access token)
         new_follows: list[dict] = []
         if access_token:
-            auth_headers = {"Authorization": f"Bearer {access_token}"}
-            with httpx.Client(timeout=30) as client:
-                params_f: dict[str, Any] = {"types[]": "follow", "limit": 80}
-                while True:
-                    r = client.get(
-                        f"{base}/api/v1/notifications",
-                        params=params_f,
-                        headers=auth_headers,
-                    )
-                    r.raise_for_status()
-                    batch = r.json()
-                    if not batch:
-                        break
-                    stop = False
-                    for n in batch:
-                        created = datetime.fromisoformat(
-                            n["created_at"].replace("Z", "+00:00")
+            try:
+                auth_headers = {"Authorization": f"Bearer {access_token}"}
+                with httpx.Client(timeout=30) as client:
+                    params_f: dict[str, Any] = {"types[]": "follow", "limit": 80}
+                    while True:
+                        r = client.get(
+                            f"{base}/api/v1/notifications",
+                            params=params_f,
+                            headers=auth_headers,
                         )
-                        if created < since:
-                            stop = True
+                        r.raise_for_status()
+                        batch = r.json()
+                        if not batch:
                             break
-                        acct = n.get("account", {})
-                        new_follows.append({
-                            "followed_at": n["created_at"],
-                            "account": acct.get("acct", ""),
-                            "display_name": acct.get("display_name", ""),
-                            "followers": acct.get("followers_count", 0),
-                        })
-                    if stop:
-                        break
-                    link = r.headers.get("Link", "")
-                    m = re.search(r'<[^>]+\?[^>]*max_id=(\d+)[^>]*>;\s*rel="next"', link)
-                    if not m:
-                        break
-                    params_f["max_id"] = m.group(1)
-            logger.info("Mastodon: collected %d new follows since %s", len(new_follows), _iso(since))
+                        stop = False
+                        for n in batch:
+                            created = datetime.fromisoformat(
+                                n["created_at"].replace("Z", "+00:00")
+                            )
+                            if created < since:
+                                stop = True
+                                break
+                            acct = n.get("account", {})
+                            new_follows.append({
+                                "followed_at": n["created_at"],
+                                "account": acct.get("acct", ""),
+                                "display_name": acct.get("display_name", ""),
+                                "followers": acct.get("followers_count", 0),
+                            })
+                        if stop:
+                            break
+                        link = r.headers.get("Link", "")
+                        m = re.search(r'<[^>]+\?[^>]*max_id=(\d+)[^>]*>;\s*rel="next"', link)
+                        if not m:
+                            break
+                        params_f["max_id"] = m.group(1)
+                logger.info("Mastodon: collected %d new follows since %s", len(new_follows), _iso(since))
+            except Exception as exc:
+                logger.error(
+                    "Mastodon: new-follows collection failed (%s): %s — returning posts only",
+                    type(exc).__name__, exc,
+                )
 
         result: dict[str, Any] = {
             "platform": "mastodon",
@@ -140,6 +146,18 @@ def collect_mastodon(
             result["new_follows_count"] = len(new_follows)
         return result
 
+    except httpx.TimeoutException as exc:
+        logger.error("Mastodon collection timed out (%s): %s", type(exc).__name__, exc)
+        return None
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "Mastodon HTTP %s from %s: %s",
+            exc.response.status_code, exc.request.url, exc.response.text[:300],
+        )
+        return None
+    except httpx.HTTPError as exc:
+        logger.error("Mastodon HTTP error (%s): %s", type(exc).__name__, exc)
+        return None
     except Exception as exc:
-        logger.error("Mastodon collection failed: %s", exc)
+        logger.error("Mastodon collection failed (%s): %s", type(exc).__name__, exc)
         return None

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -135,6 +135,39 @@ class TestCollectMastodon:
         result = collect_mastodon("hachyderm.io", "cate", since=SINCE)
         assert result["posts"][0]["has_attachment"] is True
 
+    def test_new_follows_failure_still_returns_posts(self, respx_mock):
+        """If the notifications API fails, posts already collected are still returned."""
+        respx_mock.get("https://hachyderm.io/api/v1/accounts/lookup").mock(
+            return_value=httpx.Response(200, json=self._account())
+        )
+        respx_mock.get("https://hachyderm.io/api/v1/accounts/123/statuses").mock(
+            side_effect=[
+                httpx.Response(200, json=[self._post("p1")]),
+                httpx.Response(200, json=[]),
+            ]
+        )
+        respx_mock.get("https://hachyderm.io/api/v1/notifications").mock(
+            return_value=httpx.Response(401)
+        )
+        result = collect_mastodon("hachyderm.io", "cate", since=SINCE, access_token="tok")
+        assert result is not None
+        assert len(result["posts"]) == 1
+        assert "new_follows" not in result
+
+    def test_lookup_timeout_returns_none(self, respx_mock):
+        respx_mock.get("https://hachyderm.io/api/v1/accounts/lookup").mock(
+            side_effect=httpx.TimeoutException("timed out")
+        )
+        result = collect_mastodon("hachyderm.io", "cate", since=SINCE)
+        assert result is None
+
+    def test_lookup_http_status_error_returns_none(self, respx_mock):
+        respx_mock.get("https://hachyderm.io/api/v1/accounts/lookup").mock(
+            return_value=httpx.Response(500, text="server error")
+        )
+        result = collect_mastodon("hachyderm.io", "cate", since=SINCE)
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Bluesky


### PR DESCRIPTION
## What changed

- **Split the catch-all `except Exception`** into typed handlers (`TimeoutException`, `HTTPStatusError`, `HTTPError`, `Exception`) on the outer try — logs now show the exception class and, for HTTP status errors, the status code and response body. Matches what we did for GoatCounter in #32.
- **Isolate the new-follows collection** in its own inner try/except. Previously, a token expiry or API error on `/api/v1/notifications` would discard the posts already collected and return `None`. Now it logs the error and returns the posts-only result.

## Why

The other Claude flagged `mastodon-latest.json` as showing `{"mastodon": {}}`. Investigation showed this file is a stale artifact — the collector code cannot produce `{}` (it returns `None` or a full dict). The collector last worked successfully in W21 with 14 posts. However, the error logging was poor and the new-follows failure mode was a real latent bug worth fixing.

## Tests

- `test_new_follows_failure_still_returns_posts`: 401 on notifications → posts returned, no `new_follows` key
- `test_lookup_timeout_returns_none`: `TimeoutException` → None
- `test_lookup_http_status_error_returns_none`: 500 → None
- All 350 tests pass.

## Validation

No real-data run needed — the mastodon collector was working as of W21 and the code path is covered by the existing + new tests.