### PR TITLE
Fix goatcounter display key and jetpack non-interactive reauth crash

### DIFF
--- a/collectors/jetpack.py
+++ b/collectors/jetpack.py
@@ -186,7 +186,11 @@ def collect_jetpack(
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 403 and can_reauth:
             logger.warning("Jetpack: 403 — token expired, prompting for WordPress.com password")
-            password = getpass.getpass(f"WordPress.com password for {username}: ")
+            try:
+                password = getpass.getpass(f"WordPress.com password for {username}: ")
+            except (EOFError, KeyboardInterrupt):
+                logger.error("Jetpack: cannot prompt for password in non-interactive session — skipping")
+                return None
             new_token = _reauth_jetpack(client_id, client_secret, username, password)
             if new_token:
                 try:

--- a/run.py
+++ b/run.py
@@ -256,7 +256,7 @@ def _platform_summary(name: str, data: dict) -> str:
         if name == "amazon":
             return f"{len(data.get('by_marketplace', {}))} marketplace(s)"
         if name == "goatcounter":
-            return f"{data.get('total_pageviews', '?')} pageviews"
+            return f"{data.get('total_visitors', '?')} visitors, {data.get('total_events', '?')} events"
         if name == "oreilly":
             count = data.get("payment_count", 0)
             total = data.get("total_paid", 0.0)


### PR DESCRIPTION
## What changed

- **GoatCounter summary display**: `_platform_summary` was reading `total_pageviews` (old key from a prior collector version); the collector has written `total_visitors`/`total_events` for some time. Now shows e.g. "36 visitors, 14 events" instead of "? pageviews".
- **Jetpack reauth crash**: when the Jetpack token expires and the collector tries to prompt for a WordPress.com password via `getpass.getpass()`, it raises `EOFError` in non-interactive sessions (no controlling tty). This propagated up and crashed the entire `collect_all` run, losing all data already collected. Now catches `EOFError`/`KeyboardInterrupt` and returns `None` gracefully.

## Tests

352 tests pass. No new tests needed — the jetpack fix is a defensive catch on a terminal-control operation that can't be unit-tested without a real tty, and the display fix is a one-liner key rename.

## Validation

Confirmed on a live `--months 3` run: Jetpack logs "cannot prompt for password in non-interactive session — skipping" and the run completes with 11 other platforms collected.