### PR TITLE
Fix calendly missing upcoming bookings

### DIFF
--- a/collectors/calendly.py
+++ b/collectors/calendly.py
@@ -47,21 +47,32 @@ def collect_calendly(
                 et["uri"]: et["name"] for et in event_types_raw
             }
 
-            # Fetch scheduled events within the lookback window
+            # Fetch scheduled events within the lookback window.
+            # Active events: no max_start_time so upcoming booked sessions are included.
+            # Canceled events: bounded by now (only past cancellations are relevant).
             now = _utcnow()
-            params = {
-                "user": user_uri,
-                "min_start_time": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "max_start_time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "count": 100,
-                "status": "active",
-            }
-            r = client.get(f"{base}/scheduled_events", params=params)
+            r = client.get(
+                f"{base}/scheduled_events",
+                params={
+                    "user": user_uri,
+                    "min_start_time": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "count": 100,
+                    "status": "active",
+                },
+            )
             r.raise_for_status()
             active_events = r.json().get("collection", [])
 
-            params["status"] = "canceled"
-            r = client.get(f"{base}/scheduled_events", params=params)
+            r = client.get(
+                f"{base}/scheduled_events",
+                params={
+                    "user": user_uri,
+                    "min_start_time": since.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "max_start_time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "count": 100,
+                    "status": "canceled",
+                },
+            )
             r.raise_for_status()
             canceled_events = r.json().get("collection", [])
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1778,6 +1778,39 @@ class TestCollectCalendly:
         result = collect_calendly("tok", since=SINCE, lead_gen_event="Nonexistent Event")
         assert result["lead_gen_bookings"] == 0
 
+    def test_active_events_fetched_without_max_start_time(self, respx_mock):
+        """Active events have no max_start_time so future-scheduled bookings are counted."""
+        _calendly_mock(respx_mock)
+        active_request = None
+
+        def side_effect(request):
+            nonlocal active_request
+            params = dict(request.url.params)
+            if params.get("status") == "active":
+                active_request = request
+                return httpx.Response(200, json={"collection": []})
+            return httpx.Response(200, json={"collection": []})
+
+        respx_mock.get("https://api.calendly.com/scheduled_events").mock(side_effect=side_effect)
+        collect_calendly("tok", since=SINCE)
+        assert active_request is not None
+        assert "max_start_time" not in dict(active_request.url.params)
+
+    def test_upcoming_booking_counted(self, respx_mock):
+        """A booking whose session start is in the future is still counted as active."""
+        _calendly_mock(respx_mock)
+        future_event = [{"event_type": ET_URI_INTRO}]
+
+        def side_effect(request):
+            params = dict(request.url.params)
+            if params.get("status") == "active":
+                return httpx.Response(200, json={"collection": future_event})
+            return httpx.Response(200, json={"collection": []})
+
+        respx_mock.get("https://api.calendly.com/scheduled_events").mock(side_effect=side_effect)
+        result = collect_calendly("tok", since=SINCE)
+        assert result["total_bookings"] == 1
+
     def test_no_lead_gen_event_omits_field(self, respx_mock):
         _calendly_mock(respx_mock)
         respx_mock.get("https://api.calendly.com/scheduled_events").mock(


### PR DESCRIPTION
## What changed

Active events were fetched with `max_start_time = now`, which excluded any session scheduled in the future. A coaching intro booked today for next week has a start_time in the future, so it was silently dropped — causing the 2-week run to report 0 bookings even when there were real active ones.

Fix: remove `max_start_time` from the active events query. Upcoming booked sessions now count. Canceled events keep the upper bound since only past cancellations are relevant as a metric.

## Validation

Live test with `--platform calendly`: was returning 0, now returns 1 (a booking scheduled for the future).

## Tests

- `test_active_events_fetched_without_max_start_time`: asserts the param is absent from the active request
- `test_upcoming_booking_counted`: a future-dated booking is counted in total_bookings
- 354 tests pass