### PR TITLE
Fix Vercel analytics for v2 API endpoint

### DIFF
--- a/collectors/vercel.py
+++ b/collectors/vercel.py
@@ -28,7 +28,7 @@ def collect_vercel(
 
     try:
         now = _utcnow()
-        base = "https://vercel.com/api/web-analytics"
+        base = "https://vercel.com/api/web-analytics/v2"
         headers = {"Authorization": f"Bearer {token}"}
         common_params: dict[str, Any] = {
             "projectId": project_slug,
@@ -58,10 +58,9 @@ def collect_vercel(
             ref_r.raise_for_status()
             referrers_data = ref_r.json()
 
-        # overview: {"total": N, "devices": N, "bounceRate": N}
+        # overview: {"total": N, "devices": N}  (bounceRate removed in v2)
         page_views = overview.get("total")
         visitors = overview.get("devices")
-        bounce_rate = overview.get("bounceRate")
 
         # timeseries: {"data": {"groups": {"all": [{"key": "YYYY-MM-DD", "total": N, "devices": N}, ...]}}}
         daily = []
@@ -93,7 +92,6 @@ def collect_vercel(
             "since": _iso(since),
             "page_views": page_views,
             "visitors": visitors,
-            "bounce_rate_pct": bounce_rate,
             "daily": daily,
             "top_pages": top_pages,
             "top_referrers": top_referrers,

--- a/prompts/suffix.txt
+++ b/prompts/suffix.txt
@@ -17,7 +17,7 @@ Data shape notes (for interpreting the JSON):
 - jetpack: daily_views, top_posts (views this period), referrers (traffic sources aggregated across the period, sorted by views), email_subscribers (current email subscriber count), wpcom_followers (current WordPress.com follower count)
 - buttondown: subscriber_counts per newsletter; newsletters list with open_rate, click_rate, unsubscribes per issue
 - substack: emails list with subject, date, recipients, opens, open_rate, likes, comments, shares, new_signups, new_subscribers per issue
-- vercel: daily_views, visitors, top_pages, referrers, bounce_rate
+- vercel: daily (date/page_views/visitors per day), visitors, top_pages, referrers
 - amazon: by_marketplace dict — each marketplace has a list of book editions with best_sellers_rank (lower = better; rank reflects relative popularity, not unit sales), rating, reviews
 - oreilly: payment_count, total_paid, currencies, payments (list of payment_date/amount/currency/line_items objects) — these are actual royalty payments representing real book sales revenue; use oreilly as the primary book sales signal, not amazon rank
 - upcoming: sources.wordpress (scheduled blog posts with title, date, content), sources.buttondown (scheduled emails), sources.buffer (queued social posts with platform, text, scheduled_at)

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -915,11 +915,11 @@ class TestCollectAmazon:
 # ---------------------------------------------------------------------------
 
 class TestCollectVercel:
-    BASE = "https://vercel.com/api/web-analytics"
+    BASE = "https://vercel.com/api/web-analytics/v2"
 
     def _mock_all(self, respx_mock):
         respx_mock.get(f"{self.BASE}/overview").mock(
-            return_value=httpx.Response(200, json={"total": 1000, "devices": 800, "bounceRate": 45.0})
+            return_value=httpx.Response(200, json={"total": 1000, "devices": 800})
         )
         respx_mock.get(f"{self.BASE}/timeseries").mock(
             return_value=httpx.Response(200, json={"data": {"groups": {"all": [
@@ -939,6 +939,7 @@ class TestCollectVercel:
         assert result["page_views"] == 1000
         assert result["visitors"] == 800
         assert len(result["daily"]) == 2
+        assert "bounce_rate_pct" not in result
 
     def test_daily_entries_mapped(self, respx_mock):
         self._mock_all(respx_mock)


### PR DESCRIPTION
## Summary
- Vercel moved their internal web analytics API from `/api/web-analytics/*` to `/api/web-analytics/v2/*`
- The v2 endpoint drops `bounceRate` from the overview response (removed from result dict and suffix.txt notes)
- Tests updated to match v2 response format and assert `bounce_rate_pct` is no longer present

## Test plan
- [x] All 354 tests pass
- [x] Live collection verified: 925 page views, 428 visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)