### PR TITLE
Add Stripe collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ Gives you the search queries that bring people to your site and which pages they
 4. Set `gsc_credentials_file: /path/to/service-account.json` in `config.yaml`
 5. Install extra dependencies: `pip install google-api-python-client google-auth`
 
+**Stripe** (sales — supports multiple accounts)
+1. In the Stripe dashboard → Developers → API keys → **Create restricted key**
+2. Give it **Read** on: Charges, Payment Intents, Checkout Sessions, Invoices, Customers, Balance transactions, Products
+3. Add to `config.yaml` — two shapes are supported:
+   ```yaml
+   # Preferred for many accounts:
+   stripe_tokens:
+     primary: rk_live_YOUR_KEY_HERE
+     secondary: rk_live_YOUR_OTHER_KEY_HERE
+
+   # Or flat keys — any config key starting with stripe_token_ becomes one account:
+   stripe_token_primary: rk_live_YOUR_KEY_HERE
+   ```
+4. Labels (`primary`, `secondary`, whatever you call them) are yours to choose — the collector groups everything by label.
+5. Checkout session metadata is preserved intact so you can classify sales by whatever product/cohort/tag scheme you use.
+
 ---
 
 ### Optional add-ons (extend existing credentials)

--- a/analyse.py
+++ b/analyse.py
@@ -152,6 +152,25 @@ def _trim_data(data: dict[str, Any], months: int | None = None) -> dict[str, Any
     for post in data.get("upcoming", {}).get("sources", {}).get("wordpress", []):
         post["content"] = post.get("content", "")[:500]
 
+    # Stripe: keep monthly rollup and metadata-bearing session records; strip
+    # PII (customer_email) and drop the product catalogue since it's static.
+    # Cap paid_sessions at 40 most-recent per account.
+    stripe_data = data.get("stripe")
+    if stripe_data:
+        for label, acct in (stripe_data.get("accounts") or {}).items():
+            acct.pop("products", None)
+            sessions = acct.get("paid_sessions") or []
+            for s in sessions:
+                s.pop("customer_email", None)
+                s.pop("id", None)
+            if len(sessions) > 40:
+                sessions.sort(key=lambda s: s.get("created") or 0, reverse=True)
+                acct["paid_sessions"] = sessions[:40]
+                acct["paid_sessions_note"] = f"Showing most recent 40 of {len(sessions)} paid sessions"
+            invoices = acct.get("paid_invoices") or []
+            for inv in invoices:
+                inv.pop("id", None)
+
     return data
 
 

--- a/collectors/__init__.py
+++ b/collectors/__init__.py
@@ -11,6 +11,7 @@ from collectors.mentions import collect_mentions
 from collectors.goatcounter import collect_goatcounter
 from collectors.oreilly import collect_oreilly, _parse_oreilly_eml
 from collectors.calendly import collect_calendly
+from collectors.stripe import collect_stripe
 from collectors._dispatch import collect_all, PLATFORM_COLLECTORS
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "collect_oreilly",
     "_parse_oreilly_eml",
     "collect_calendly",
+    "collect_stripe",
     "collect_all",
     "PLATFORM_COLLECTORS",
 ]

--- a/collectors/_dispatch.py
+++ b/collectors/_dispatch.py
@@ -18,8 +18,35 @@ from collectors.mentions import collect_mentions
 from collectors.goatcounter import collect_goatcounter
 from collectors.oreilly import collect_oreilly
 from collectors.calendly import collect_calendly
+from collectors.stripe import collect_stripe
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_stripe_tokens(config: dict) -> dict[str, str]:
+    """
+    Extract Stripe tokens from config. Supports two shapes:
+
+    1. `stripe_tokens: {label: key, ...}` — dict of user-labelled accounts.
+    2. Flat keys `stripe_token_<label>: key` — any config key matching this
+       prefix is treated as one Stripe account (label is the suffix).
+
+    Empty tokens are dropped. Returns {} if no tokens configured.
+    """
+    tokens: dict[str, str] = {}
+    dict_form = config.get("stripe_tokens") or {}
+    if isinstance(dict_form, dict):
+        for label, key in dict_form.items():
+            if key:
+                tokens[str(label)] = str(key)
+    for k, v in config.items():
+        if not isinstance(k, str) or not k.startswith("stripe_token_"):
+            continue
+        label = k[len("stripe_token_"):]
+        if label and v:
+            tokens[label] = str(v)
+    return tokens
+
 
 PLATFORM_COLLECTORS = {
     "mastodon": "collect_mastodon",
@@ -35,6 +62,7 @@ PLATFORM_COLLECTORS = {
     "goatcounter": "collect_goatcounter",
     "oreilly": "collect_oreilly",
     "calendly": "collect_calendly",
+    "stripe": "collect_stripe",
 }
 
 
@@ -163,6 +191,12 @@ def collect_all(
                 logger.info("Calendly: calendly_token not configured — skipping")
                 return
             data = collect_calendly(calendly_token, since=since, lead_gen_event=config.get("calendly_lead_gen_event") or None)
+        elif name == "stripe":
+            tokens = _resolve_stripe_tokens(config)
+            if not tokens:
+                logger.info("Stripe: no tokens configured — skipping")
+                return
+            data = collect_stripe(tokens, since=since)
         else:
             logger.error("Unknown platform: %s", name)
             return

--- a/collectors/stripe.py
+++ b/collectors/stripe.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from collectors._helpers import _utcnow, _iso, _default_since
+
+logger = logging.getLogger(__name__)
+
+STRIPE_BASE = "https://api.stripe.com/v1"
+
+
+def _all_pages(
+    client: httpx.Client,
+    auth: tuple[str, str],
+    endpoint: str,
+    params: dict[str, Any],
+) -> list[dict] | None:
+    """Paginate a Stripe list endpoint. Returns None on failure, [] on empty."""
+    out: list[dict] = []
+    starting_after: str | None = None
+    while True:
+        p = dict(params)
+        if starting_after:
+            p["starting_after"] = starting_after
+        r = client.get(f"{STRIPE_BASE}/{endpoint}", auth=auth, params=p)
+        if not r.is_success:
+            logger.error(
+                "Stripe %s failed: HTTP %s — %s",
+                endpoint, r.status_code, r.text[:200],
+            )
+            return None
+        payload = r.json()
+        batch = payload.get("data", [])
+        out.extend(batch)
+        if not payload.get("has_more") or not batch:
+            break
+        starting_after = batch[-1]["id"]
+    return out
+
+
+def _collect_one_account(
+    label: str,
+    token: str,
+    since: datetime,
+) -> dict[str, Any] | None:
+    """Collect data for a single Stripe account (identified by user-chosen label)."""
+    auth = (token, "")
+    since_ts = int(since.timestamp())
+    now = _utcnow()
+
+    with httpx.Client(timeout=30) as client:
+        products = _all_pages(client, auth, "products", {"limit": 100})
+        if products is None:
+            logger.error("Stripe [%s]: could not fetch products — aborting account", label)
+            return None
+
+        charges = _all_pages(
+            client, auth, "charges",
+            {"limit": 100, "created[gte]": since_ts},
+        )
+        sessions = _all_pages(
+            client, auth, "checkout/sessions",
+            {"limit": 100, "created[gte]": since_ts},
+        )
+        # Invoices need an extra scope — soft-fail
+        invoices = _all_pages(
+            client, auth, "invoices",
+            {"limit": 100, "created[gte]": since_ts},
+        )
+
+    charges = charges or []
+    sessions = sessions or []
+    invoices = invoices or []
+
+    succeeded = [c for c in charges if c.get("status") == "succeeded"]
+    paid_sessions = [s for s in sessions if s.get("payment_status") == "paid"]
+    paid_invoices = [i for i in invoices if i.get("status") == "paid"]
+
+    # Monthly rollup by charge date
+    monthly: dict[str, dict[str, int]] = defaultdict(lambda: {"count": 0, "gross_cents": 0})
+    for c in succeeded:
+        m = datetime.fromtimestamp(c["created"], tz=timezone.utc).strftime("%Y-%m")
+        monthly[m]["count"] += 1
+        monthly[m]["gross_cents"] += c.get("amount", 0) or 0
+
+    # Default currency (best-effort — first non-empty)
+    currency = next(
+        (c.get("currency") for c in succeeded if c.get("currency")),
+        "usd",
+    )
+
+    gross_cents = sum((c.get("amount") or 0) for c in succeeded)
+    refunded_cents = sum((c.get("amount_refunded") or 0) for c in charges)
+
+    # Slim per-session records — preserve metadata for downstream classification
+    session_records = []
+    for s in paid_sessions:
+        session_records.append({
+            "id": s["id"],
+            "created": s.get("created"),
+            "amount_cents": s.get("amount_total"),
+            "currency": s.get("currency"),
+            "metadata": s.get("metadata") or {},
+            "customer_email": (s.get("customer_details") or {}).get("email"),
+        })
+
+    # Invoice records with line-item descriptions preserved
+    invoice_records = []
+    for i in paid_invoices:
+        invoice_records.append({
+            "id": i["id"],
+            "created": i.get("created"),
+            "amount_paid_cents": i.get("amount_paid"),
+            "currency": i.get("currency"),
+            "lines": [
+                {
+                    "description": li.get("description"),
+                    "amount_cents": li.get("amount"),
+                }
+                for li in (i.get("lines") or {}).get("data", [])
+            ],
+        })
+
+    product_records = [
+        {
+            "id": p["id"],
+            "name": p.get("name"),
+            "active": p.get("active", False),
+        }
+        for p in products
+    ]
+
+    return {
+        "label": label,
+        "collected_at": _iso(now),
+        "since": _iso(since),
+        "currency": currency,
+        "products": product_records,
+        "charges_succeeded": len(succeeded),
+        "gross_cents": gross_cents,
+        "refunded_cents": refunded_cents,
+        "monthly": [
+            {"month": m, "count": v["count"], "gross_cents": v["gross_cents"]}
+            for m, v in sorted(monthly.items())
+        ],
+        "paid_sessions": session_records,
+        "paid_invoices": invoice_records,
+    }
+
+
+def collect_stripe(
+    tokens: dict[str, str],
+    since: datetime | None = None,
+) -> dict[str, Any] | None:
+    """
+    Collect Stripe data (charges, checkout sessions, invoices, products) from
+    one or more Stripe accounts.
+
+    Args:
+        tokens: mapping of user-chosen label → Stripe restricted key. Supports
+            multi-account setups (e.g. `{"primary": "rk_...", "secondary": "rk_..."}`).
+        since: earliest `created` timestamp to include. Defaults to 14 days back.
+
+    Returns:
+        A dict of the form::
+
+            {
+                "platform": "stripe",
+                "collected_at": "...",
+                "since": "...",
+                "accounts": {label: <per-account data>, ...},
+                "totals": {"gross_cents": int, "charges_succeeded": int},
+            }
+
+        or None if `tokens` is empty or every account failed.
+
+    All classification (which sales count as which product) is intentionally
+    left to downstream analysis — this collector preserves checkout metadata
+    intact so any project can filter/group by its own rules.
+    """
+    if not tokens:
+        return None
+    if since is None:
+        since = _default_since()
+
+    accounts: dict[str, Any] = {}
+    for label, token in tokens.items():
+        if not token:
+            logger.info("Stripe [%s]: no token — skipping", label)
+            continue
+        try:
+            data = _collect_one_account(label, token, since)
+            if data is None:
+                continue
+            accounts[label] = data
+            logger.info(
+                "Stripe [%s]: %d charges succeeded, %d paid sessions, %d paid invoices",
+                label, data["charges_succeeded"],
+                len(data["paid_sessions"]), len(data["paid_invoices"]),
+            )
+        except Exception as exc:
+            logger.error("Stripe [%s] collection failed: %s", label, exc)
+
+    if not accounts:
+        return None
+
+    totals = {
+        "gross_cents": sum(a["gross_cents"] for a in accounts.values()),
+        "charges_succeeded": sum(a["charges_succeeded"] for a in accounts.values()),
+    }
+
+    return {
+        "platform": "stripe",
+        "collected_at": _iso(_utcnow()),
+        "since": _iso(since),
+        "accounts": accounts,
+        "totals": totals,
+    }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,6 +80,26 @@ vercel_team_id:                        # Team ID if the project is in a team (op
 # linkedin_client_secret: YOUR_LINKEDIN_CLIENT_SECRET
 # linkedin_access_token:   # written automatically by --auth linkedin (valid ~60 days)
 
+# --- Stripe (optional — sales) ---
+# Restricted keys, one per account. Any user-chosen labels work.
+# Recommended scopes: charges (Read), payment_intents (Read),
+# checkout_sessions (Read), invoices (Read), customers (Read),
+# balance_transactions (Read), products (Read).
+#
+# Two equivalent shapes are supported:
+#
+# 1. Dict form (preferred for many accounts):
+# stripe_tokens:
+#   primary: rk_live_YOUR_KEY_HERE
+#   secondary: rk_live_YOUR_OTHER_KEY_HERE
+#
+# 2. Flat form (any key matching stripe_token_<label>):
+# stripe_token_primary: rk_live_YOUR_KEY_HERE
+# stripe_token_secondary: rk_live_YOUR_OTHER_KEY_HERE
+#
+# The collector preserves checkout session metadata intact so downstream
+# analysis can classify sales by whatever product/cohort scheme you use.
+
 # --- Content strategy ---
 # primary_focus: the metric or outcome you care about most. Claude uses this to frame
 # the analysis and recommend data sources that would help measure it better.

--- a/run.py
+++ b/run.py
@@ -229,6 +229,14 @@ def _platform_expected(name: str, config: dict) -> bool:
         return _has_files("oreilly_drops/*.eml", "oreilly_drops/*.rtf")
     if name == "calendly":
         return bool(config.get("calendly_token"))
+    if name == "stripe":
+        if isinstance(config.get("stripe_tokens"), dict) and any(config["stripe_tokens"].values()):
+            return True
+        return any(
+            k.startswith("stripe_token_") and v
+            for k, v in config.items()
+            if isinstance(k, str)
+        )
     return False
 
 
@@ -268,6 +276,17 @@ def _platform_summary(name: str, data: dict) -> str:
             if lead is not None:
                 return f"{bookings} booking(s) ({lead} lead gen)"
             return f"{bookings} booking(s)"
+        if name == "stripe":
+            totals = data.get("totals", {})
+            accts = data.get("accounts", {}) or {}
+            gross = (totals.get("gross_cents") or 0) / 100
+            n = totals.get("charges_succeeded") or 0
+            currency = "USD"
+            for a in accts.values():
+                if a.get("currency"):
+                    currency = a["currency"].upper()
+                    break
+            return f"{n} charge(s), {currency} {gross:,.2f} across {len(accts)} account(s)"
         if name == "mentions":
             sources = data.get("sources", {})
             hn = len(sources.get("hackernews", []))

--- a/store.py
+++ b/store.py
@@ -83,6 +83,7 @@ def get_known_platforms(store_path: Path = STORE_PATH) -> set[str]:
             "vercel": "vercel",
             "amazon": "amazon",
             "mentions": "mentions",
+            "stripe": "stripe",
         }
         for sheet in xl.sheet_names:
             for prefix, platform in prefix_map.items():
@@ -307,6 +308,76 @@ def _process_amazon(collected: dict, sheets: dict, store_path: Path, now: str) -
         sheets["amazon"] = _upsert(_load(store_path, "amazon"), df_new, ["asin", "marketplace"])
 
 
+def _process_stripe(collected: dict, sheets: dict, store_path: Path, now: str) -> None:
+    """
+    Persist Stripe data:
+      - stripe_monthly: (account, month) → count, gross_cents, currency
+      - stripe_sessions: paid checkout sessions with metadata flattened to JSON
+      - stripe_invoices: paid invoices with line-item summary
+      - stripe_products: current product catalogue per account
+    """
+    import json as _json
+    accounts = collected.get("accounts", {}) or {}
+
+    monthly_rows = []
+    session_rows = []
+    invoice_rows = []
+    product_rows = []
+    for label, acct in accounts.items():
+        currency = (acct.get("currency") or "usd").upper()
+        for m in acct.get("monthly", []) or []:
+            monthly_rows.append({
+                "account": label,
+                "month": m.get("month", ""),
+                "count": m.get("count", 0),
+                "gross_cents": m.get("gross_cents", 0),
+                "currency": currency,
+                "last_updated": now,
+            })
+        for s in acct.get("paid_sessions", []) or []:
+            session_rows.append({
+                "session_id": s.get("id", ""),
+                "account": label,
+                "created": s.get("created", ""),
+                "amount_cents": s.get("amount_cents") or 0,
+                "currency": (s.get("currency") or "").upper() or currency,
+                "customer_email": s.get("customer_email") or "",
+                "metadata_json": _json.dumps(s.get("metadata") or {}, sort_keys=True),
+                "last_updated": now,
+            })
+        for i in acct.get("paid_invoices", []) or []:
+            invoice_rows.append({
+                "invoice_id": i.get("id", ""),
+                "account": label,
+                "created": i.get("created", ""),
+                "amount_paid_cents": i.get("amount_paid_cents") or 0,
+                "currency": (i.get("currency") or "").upper() or currency,
+                "lines_json": _json.dumps(i.get("lines") or [], sort_keys=True),
+                "last_updated": now,
+            })
+        for p in acct.get("products", []) or []:
+            product_rows.append({
+                "product_id": p.get("id", ""),
+                "account": label,
+                "name": p.get("name", "") or "",
+                "active": bool(p.get("active", False)),
+                "last_updated": now,
+            })
+
+    if monthly_rows:
+        df = pd.DataFrame(monthly_rows)
+        sheets["stripe_monthly"] = _upsert(_load(store_path, "stripe_monthly"), df, ["account", "month"])
+    if session_rows:
+        df = pd.DataFrame(session_rows)
+        sheets["stripe_sessions"] = _upsert(_load(store_path, "stripe_sessions"), df, ["session_id"])
+    if invoice_rows:
+        df = pd.DataFrame(invoice_rows)
+        sheets["stripe_invoices"] = _upsert(_load(store_path, "stripe_invoices"), df, ["invoice_id"])
+    if product_rows:
+        df = pd.DataFrame(product_rows)
+        sheets["stripe_products"] = _upsert(_load(store_path, "stripe_products"), df, ["product_id", "account"])
+
+
 def _process_mentions(collected: dict, sheets: dict, store_path: Path, now: str) -> None:
     sources = collected.get("sources", {})
 
@@ -379,6 +450,7 @@ _PROCESSORS = {
     "vercel": _process_vercel,
     "amazon": _process_amazon,
     "mentions": _process_mentions,
+    "stripe": _process_stripe,
 }
 
 

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -1,0 +1,277 @@
+"""
+Tests for collectors/stripe.py and its wiring.
+All HTTP is mocked with respx; no real Stripe key needed.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pandas as pd
+import pytest
+import respx
+
+from collectors.stripe import collect_stripe
+from collectors._dispatch import _resolve_stripe_tokens
+from store import _process_stripe, _load
+
+SINCE = datetime(2025, 12, 1, tzinfo=timezone.utc)
+STRIPE = "https://api.stripe.com/v1"
+
+
+def _products_response(items):
+    return {"object": "list", "has_more": False, "data": items}
+
+
+def _paginated(items, has_more=False):
+    return {"object": "list", "has_more": has_more, "data": items}
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveTokens:
+    def test_dict_form(self):
+        cfg = {"stripe_tokens": {"a": "rk_1", "b": "rk_2"}}
+        assert _resolve_stripe_tokens(cfg) == {"a": "rk_1", "b": "rk_2"}
+
+    def test_flat_form(self):
+        cfg = {"stripe_token_primary": "rk_1", "stripe_token_secondary": "rk_2"}
+        assert _resolve_stripe_tokens(cfg) == {"primary": "rk_1", "secondary": "rk_2"}
+
+    def test_mixed(self):
+        cfg = {"stripe_tokens": {"a": "rk_1"}, "stripe_token_b": "rk_2"}
+        assert _resolve_stripe_tokens(cfg) == {"a": "rk_1", "b": "rk_2"}
+
+    def test_flat_overrides_dict_on_same_label(self):
+        cfg = {"stripe_tokens": {"a": "rk_1"}, "stripe_token_a": "rk_2"}
+        # Flat form runs second, wins
+        assert _resolve_stripe_tokens(cfg)["a"] == "rk_2"
+
+    def test_ignores_empty_values(self):
+        cfg = {"stripe_tokens": {"a": "", "b": None}, "stripe_token_c": ""}
+        assert _resolve_stripe_tokens(cfg) == {}
+
+    def test_ignores_unrelated_keys(self):
+        cfg = {"stripe_token": "should-not-appear", "other_key": "x"}
+        # "stripe_token" (no trailing _label) has no suffix → skipped
+        assert _resolve_stripe_tokens(cfg) == {}
+
+    def test_no_tokens_returns_empty(self):
+        assert _resolve_stripe_tokens({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# collect_stripe
+# ---------------------------------------------------------------------------
+
+class TestCollectStripe:
+    def test_empty_tokens_returns_none(self):
+        assert collect_stripe({}, since=SINCE) is None
+
+    def test_all_empty_tokens_returns_none(self):
+        assert collect_stripe({"a": "", "b": None}, since=SINCE) is None
+
+    def test_happy_path_single_account(self, respx_mock):
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([
+                {"id": "prod_1", "name": "Course A", "active": True},
+            ]))
+        )
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(200, json=_paginated([
+                {"id": "ch_1", "status": "succeeded", "amount": 49900,
+                 "amount_refunded": 0, "currency": "usd",
+                 "created": int(datetime(2026, 2, 15, tzinfo=timezone.utc).timestamp())},
+                {"id": "ch_2", "status": "succeeded", "amount": 24950,
+                 "amount_refunded": 0, "currency": "usd",
+                 "created": int(datetime(2026, 3, 3, tzinfo=timezone.utc).timestamp())},
+                {"id": "ch_3", "status": "failed", "amount": 10000,
+                 "amount_refunded": 0, "currency": "usd",
+                 "created": int(datetime(2026, 3, 5, tzinfo=timezone.utc).timestamp())},
+            ]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([
+                {"id": "cs_1", "payment_status": "paid", "amount_total": 49900,
+                 "currency": "usd", "created": 1740000000,
+                 "metadata": {"courseName": "Course A", "cohortName": "Feb 2026"},
+                 "customer_details": {"email": "a@b.com"}},
+                {"id": "cs_2", "payment_status": "unpaid", "amount_total": 100,
+                 "currency": "usd", "created": 1740000100,
+                 "metadata": {}},
+            ]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([
+                {"id": "in_1", "status": "paid", "amount_paid": 449500,
+                 "currency": "usd", "created": 1741000000,
+                 "lines": {"data": [
+                     {"description": "Course A Enrollment", "amount": 449500},
+                 ]}},
+            ]))
+        )
+
+        result = collect_stripe({"primary": "rk_test"}, since=SINCE)
+
+        assert result is not None
+        assert result["platform"] == "stripe"
+        assert set(result["accounts"].keys()) == {"primary"}
+        acct = result["accounts"]["primary"]
+
+        assert acct["charges_succeeded"] == 2  # failed charge excluded
+        assert acct["gross_cents"] == 49900 + 24950
+        assert len(acct["monthly"]) == 2
+        # sessions: only paid ones flow through
+        assert len(acct["paid_sessions"]) == 1
+        assert acct["paid_sessions"][0]["metadata"]["courseName"] == "Course A"
+        # invoice
+        assert len(acct["paid_invoices"]) == 1
+        assert acct["paid_invoices"][0]["lines"][0]["description"] == "Course A Enrollment"
+        # totals rollup
+        assert result["totals"]["gross_cents"] == 74850
+
+    def test_invoices_permission_denied_soft_fails(self, respx_mock):
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([]))
+        )
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(403, json={"error": {"message": "no perm"}})
+        )
+        result = collect_stripe({"primary": "rk_test"}, since=SINCE)
+        assert result is not None
+        assert result["accounts"]["primary"]["paid_invoices"] == []
+
+    def test_products_hard_fail_skips_account(self, respx_mock):
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(401, json={"error": {"message": "bad key"}})
+        )
+        result = collect_stripe({"primary": "rk_bad"}, since=SINCE)
+        assert result is None
+
+    def test_multi_account_partial_failure(self, respx_mock):
+        # Route both keys through matching responses. respx matches on URL only,
+        # not auth — so we simulate one account working and the other failing
+        # by making products fail for the SECOND call using side_effect.
+        respx_mock.get(f"{STRIPE}/products").mock(side_effect=[
+            httpx.Response(200, json=_products_response([])),
+            httpx.Response(401, json={"error": {"message": "bad"}}),
+        ])
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+
+        result = collect_stripe({"good": "rk_1", "bad": "rk_2"}, since=SINCE)
+        assert result is not None
+        assert set(result["accounts"].keys()) == {"good"}
+
+    def test_monthly_rollup_groups_by_utc_month(self, respx_mock):
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([]))
+        )
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(200, json=_paginated([
+                {"id": "ch_1", "status": "succeeded", "amount": 1000, "currency": "usd",
+                 "created": int(datetime(2026, 1, 15, tzinfo=timezone.utc).timestamp())},
+                {"id": "ch_2", "status": "succeeded", "amount": 2000, "currency": "usd",
+                 "created": int(datetime(2026, 1, 20, tzinfo=timezone.utc).timestamp())},
+                {"id": "ch_3", "status": "succeeded", "amount": 3000, "currency": "usd",
+                 "created": int(datetime(2026, 2, 1, tzinfo=timezone.utc).timestamp())},
+            ]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        result = collect_stripe({"a": "rk"}, since=SINCE)
+        monthly = {m["month"]: m for m in result["accounts"]["a"]["monthly"]}
+        assert monthly["2026-01"]["count"] == 2
+        assert monthly["2026-01"]["gross_cents"] == 3000
+        assert monthly["2026-02"]["count"] == 1
+        assert monthly["2026-02"]["gross_cents"] == 3000
+
+
+# ---------------------------------------------------------------------------
+# Store persistence
+# ---------------------------------------------------------------------------
+
+class TestProcessStripe:
+    def test_writes_monthly_sessions_invoices_products(self, tmp_path):
+        store_path = tmp_path / "analytics.xlsx"
+        collected = {
+            "accounts": {
+                "primary": {
+                    "currency": "usd",
+                    "monthly": [
+                        {"month": "2026-01", "count": 3, "gross_cents": 15000},
+                        {"month": "2026-02", "count": 1, "gross_cents": 49900},
+                    ],
+                    "paid_sessions": [
+                        {"id": "cs_1", "created": 1740000000, "amount_cents": 49900,
+                         "currency": "usd", "metadata": {"courseName": "A"},
+                         "customer_email": "x@y.com"},
+                    ],
+                    "paid_invoices": [
+                        {"id": "in_1", "created": 1741000000,
+                         "amount_paid_cents": 449500, "currency": "usd",
+                         "lines": [{"description": "Course A", "amount_cents": 449500}]},
+                    ],
+                    "products": [
+                        {"id": "prod_1", "name": "Course A", "active": True},
+                    ],
+                }
+            }
+        }
+        sheets: dict = {}
+        _process_stripe(collected, sheets, store_path, "2026-07-10 12:00:00")
+
+        assert set(sheets.keys()) == {
+            "stripe_monthly", "stripe_sessions", "stripe_invoices", "stripe_products",
+        }
+        assert len(sheets["stripe_monthly"]) == 2
+        assert sheets["stripe_sessions"].iloc[0]["session_id"] == "cs_1"
+        assert "courseName" in sheets["stripe_sessions"].iloc[0]["metadata_json"]
+        assert sheets["stripe_invoices"].iloc[0]["invoice_id"] == "in_1"
+        assert sheets["stripe_products"].iloc[0]["name"] == "Course A"
+
+    def test_empty_accounts_writes_nothing(self, tmp_path):
+        store_path = tmp_path / "analytics.xlsx"
+        sheets: dict = {}
+        _process_stripe({"accounts": {}}, sheets, store_path, "2026-07-10 12:00:00")
+        assert sheets == {}
+
+    def test_multi_account_writes_all(self, tmp_path):
+        store_path = tmp_path / "analytics.xlsx"
+        collected = {
+            "accounts": {
+                "a": {
+                    "currency": "usd",
+                    "monthly": [{"month": "2026-01", "count": 1, "gross_cents": 100}],
+                    "paid_sessions": [], "paid_invoices": [], "products": [],
+                },
+                "b": {
+                    "currency": "usd",
+                    "monthly": [{"month": "2026-01", "count": 2, "gross_cents": 500}],
+                    "paid_sessions": [], "paid_invoices": [], "products": [],
+                },
+            }
+        }
+        sheets: dict = {}
+        _process_stripe(collected, sheets, store_path, "2026-07-10 12:00:00")
+        rows = sheets["stripe_monthly"]
+        assert set(rows["account"]) == {"a", "b"}


### PR DESCRIPTION
## Summary

Adds a Stripe collector as a new platform. Multi-account (any number of Stripe keys) via either shape:

```yaml
# dict form:
stripe_tokens:
  primary: rk_live_...
  secondary: rk_live_...

# or flat — any key starting with stripe_token_<label>:
stripe_token_primary: rk_live_...
```

Pulls charges, checkout sessions, invoices, and products since the standard 2-week window (or `--months N`). Preserves **checkout session metadata intact** (`courseName`, `cohortName`, whatever you set at checkout time) so any project can classify sales by its own scheme — no DRI-specific rules baked in.

## What ships

- `collectors/stripe.py` — new collector, multi-account, per-account soft failures
- `collectors/_dispatch.py` — registers `stripe`; helper `_resolve_stripe_tokens` supports both config shapes
- `store.py` — adds `_process_stripe` writing four new sheets to `analytics.xlsx`:
  - `stripe_monthly` — (account, month) rollup
  - `stripe_sessions` — paid checkout sessions with metadata as JSON
  - `stripe_invoices` — paid invoices with line-item summary
  - `stripe_products` — current product catalogue per account
- `analyse.py` — trims prompt (strips PII, caps recent sessions at 40 most-recent per account)
- `run.py` — `_platform_expected` + `_platform_summary` recognise Stripe
- `config.example.yaml` — commented example showing both config shapes
- `README.md` — new "Stripe" section under Platform setup with required restricted-key scopes

## Tests

`tests/test_stripe.py` — 17 new cases, all mocked with `respx`:

- token resolution (dict form, flat form, mixed, precedence, empty values, unrelated keys)
- happy path: charges/sessions/invoices with metadata preserved
- invoices 403 → soft-fail (returns empty list, doesn't kill the collection)
- products 401 → hard-fail on that account (skipped from result)
- multi-account partial failure — good account survives, bad one skipped
- monthly rollup groups by UTC month
- store: writes all four sheets, empty accounts writes nothing, multi-account writes all

Result: **368 passed**, 3 pre-existing GSC failures unrelated to this change (missing optional `google-api-python-client`).

## Validation on real data

Ran full `--collect-only` with 2 configured accounts. Collected 7 charges / \$4,620.50 in the default 2-week window; store now holds 59 sessions, 36 invoices, 4 products, 6 monthly rows across both accounts (accumulated over multiple runs).

## Test plan

- [ ] `python3 -m pytest tests/test_stripe.py -v`
- [ ] Add a restricted key to `config.yaml`, run `python3 run.py --collect-only --platform stripe`, confirm the run summary shows the charge count and gross
- [ ] Confirm `data/analytics.xlsx` gains `stripe_*` sheets