### PR TITLE
Fix Stripe collector pagination and currency handling

### DIFF
--- a/collectors/stripe.py
+++ b/collectors/stripe.py
@@ -20,7 +20,15 @@ def _all_pages(
     endpoint: str,
     params: dict[str, Any],
 ) -> list[dict] | None:
-    """Paginate a Stripe list endpoint. Returns None on failure, [] on empty."""
+    """
+    Paginate a Stripe list endpoint.
+
+    Returns:
+      - list of items on success (possibly empty)
+      - partial list if a mid-pagination page fails (with a warning) so a
+        transient 5xx on page 3 of 10 doesn't discard the first two pages
+      - None only when the very first page fails
+    """
     out: list[dict] = []
     starting_after: str | None = None
     while True:
@@ -33,6 +41,12 @@ def _all_pages(
                 "Stripe %s failed: HTTP %s — %s",
                 endpoint, r.status_code, r.text[:200],
             )
+            if out:
+                logger.warning(
+                    "Stripe %s: returning %d partial results from earlier pages",
+                    endpoint, len(out),
+                )
+                return out
             return None
         payload = r.json()
         batch = payload.get("data", [])
@@ -81,21 +95,33 @@ def _collect_one_account(
     paid_sessions = [s for s in sessions if s.get("payment_status") == "paid"]
     paid_invoices = [i for i in invoices if i.get("status") == "paid"]
 
-    # Monthly rollup by charge date
+    # Aggregate in USD only. Multi-currency rollups would garble totals
+    # (adding EUR cents to USD cents), so non-USD charges are excluded
+    # from monthly/gross/refunded with a warning. Individual per-session
+    # and per-invoice records preserve their own currency for downstream.
+    def _is_usd(c: dict) -> bool:
+        return (c.get("currency") or "usd").lower() == "usd"
+
+    succeeded_usd = [c for c in succeeded if _is_usd(c)]
+    non_usd = sorted({(c.get("currency") or "").lower() for c in succeeded if not _is_usd(c)})
+    if non_usd:
+        logger.warning(
+            "Stripe [%s]: excluded %d non-USD succeeded charge(s) from aggregation "
+            "(currencies: %s). USD-only until multi-currency rollup is supported.",
+            label, len(succeeded) - len(succeeded_usd), ", ".join(non_usd),
+        )
+
+    # Monthly rollup by charge date (USD-only)
     monthly: dict[str, dict[str, int]] = defaultdict(lambda: {"count": 0, "gross_cents": 0})
-    for c in succeeded:
+    for c in succeeded_usd:
         m = datetime.fromtimestamp(c["created"], tz=timezone.utc).strftime("%Y-%m")
         monthly[m]["count"] += 1
         monthly[m]["gross_cents"] += c.get("amount", 0) or 0
 
-    # Default currency (best-effort — first non-empty)
-    currency = next(
-        (c.get("currency") for c in succeeded if c.get("currency")),
-        "usd",
-    )
+    currency = "usd"
 
-    gross_cents = sum((c.get("amount") or 0) for c in succeeded)
-    refunded_cents = sum((c.get("amount_refunded") or 0) for c in charges)
+    gross_cents = sum((c.get("amount") or 0) for c in succeeded_usd)
+    refunded_cents = sum((c.get("amount_refunded") or 0) for c in charges if _is_usd(c))
 
     # Slim per-session records — preserve metadata for downstream classification
     session_records = []
@@ -141,7 +167,7 @@ def _collect_one_account(
         "since": _iso(since),
         "currency": currency,
         "products": product_records,
-        "charges_succeeded": len(succeeded),
+        "charges_succeeded": len(succeeded_usd),
         "gross_cents": gross_cents,
         "refunded_cents": refunded_cents,
         "monthly": [
@@ -182,6 +208,11 @@ def collect_stripe(
     All classification (which sales count as which product) is intentionally
     left to downstream analysis — this collector preserves checkout metadata
     intact so any project can filter/group by its own rules.
+
+    Currency: gross/monthly/refunded aggregates are USD-only. Non-USD
+    succeeded charges are excluded from those rollups with a warning; the
+    individual charge / session / invoice records preserve their own
+    currency for downstream inspection.
     """
     if not tokens:
         return None

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -178,6 +178,113 @@ class TestCollectStripe:
         assert result is not None
         assert set(result["accounts"].keys()) == {"good"}
 
+    def test_pagination_partial_failure_returns_partial(self, respx_mock, caplog):
+        """A mid-pagination failure should return the pages already fetched."""
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        # Two charges pages: first succeeds with has_more=True, second 503s.
+        page1 = _paginated([
+            {"id": "ch_1", "status": "succeeded", "amount": 1000, "currency": "usd",
+             "created": int(datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp())},
+        ], has_more=True)
+        respx_mock.get(f"{STRIPE}/charges").mock(side_effect=[
+            httpx.Response(200, json=page1),
+            httpx.Response(503, json={"error": {"message": "temporary"}}),
+        ])
+        with caplog.at_level("WARNING"):
+            result = collect_stripe({"primary": "rk_test"}, since=SINCE)
+        # Partial result kept, not discarded
+        assert result is not None
+        assert result["accounts"]["primary"]["charges_succeeded"] == 1
+        assert result["accounts"]["primary"]["gross_cents"] == 1000
+        # Warning surfaced
+        assert any("partial results" in r.getMessage() for r in caplog.records)
+
+    def test_first_page_failure_returns_none(self, respx_mock):
+        """Failure on the very first page (no prior data) still returns None."""
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(503, json={"error": {"message": "down"}})
+        )
+        # Charges = None → treated as empty, account still returns with 0 charges
+        result = collect_stripe({"primary": "rk_test"}, since=SINCE)
+        assert result is not None
+        assert result["accounts"]["primary"]["charges_succeeded"] == 0
+        assert result["accounts"]["primary"]["gross_cents"] == 0
+
+    def test_non_usd_charges_excluded_from_aggregates(self, respx_mock, caplog):
+        """Non-USD charges are excluded from monthly/gross with a warning; USD kept."""
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(200, json=_paginated([
+                {"id": "ch_usd", "status": "succeeded", "amount": 10000,
+                 "amount_refunded": 500, "currency": "usd",
+                 "created": int(datetime(2026, 3, 1, tzinfo=timezone.utc).timestamp())},
+                {"id": "ch_eur", "status": "succeeded", "amount": 50000,
+                 "amount_refunded": 1000, "currency": "eur",
+                 "created": int(datetime(2026, 3, 5, tzinfo=timezone.utc).timestamp())},
+                {"id": "ch_gbp", "status": "succeeded", "amount": 20000,
+                 "amount_refunded": 0, "currency": "gbp",
+                 "created": int(datetime(2026, 4, 1, tzinfo=timezone.utc).timestamp())},
+            ]))
+        )
+        with caplog.at_level("WARNING"):
+            result = collect_stripe({"primary": "rk_test"}, since=SINCE)
+        acct = result["accounts"]["primary"]
+        assert acct["currency"] == "usd"
+        assert acct["charges_succeeded"] == 1  # only the USD charge
+        assert acct["gross_cents"] == 10000
+        assert acct["refunded_cents"] == 500  # non-USD refunds also excluded
+        assert len(acct["monthly"]) == 1
+        assert acct["monthly"][0]["month"] == "2026-03"
+        # Warning fired mentioning both foreign currencies
+        msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("eur" in m and "gbp" in m for m in msgs)
+
+    def test_all_usd_no_warning(self, respx_mock, caplog):
+        """When every charge is USD, no currency warning is emitted."""
+        respx_mock.get(f"{STRIPE}/products").mock(
+            return_value=httpx.Response(200, json=_products_response([]))
+        )
+        respx_mock.get(f"{STRIPE}/checkout/sessions").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/invoices").mock(
+            return_value=httpx.Response(200, json=_paginated([]))
+        )
+        respx_mock.get(f"{STRIPE}/charges").mock(
+            return_value=httpx.Response(200, json=_paginated([
+                {"id": "ch_1", "status": "succeeded", "amount": 1000, "currency": "usd",
+                 "created": int(datetime(2026, 3, 1, tzinfo=timezone.utc).timestamp())},
+            ]))
+        )
+        with caplog.at_level("WARNING"):
+            collect_stripe({"primary": "rk_test"}, since=SINCE)
+        assert not any("non-USD" in r.getMessage() for r in caplog.records)
+
     def test_monthly_rollup_groups_by_utc_month(self, respx_mock):
         respx_mock.get(f"{STRIPE}/products").mock(
             return_value=httpx.Response(200, json=_products_response([]))


### PR DESCRIPTION
## Summary

Follow-up on the Stripe collector — addresses two of the non-blocking findings from PR #39's review.

**Pagination partial failure** (`collectors/stripe.py`)
Previously, a mid-pagination non-2xx response discarded every page fetched before it (a transient 5xx on page 3 of 10 turned a 200-item result into \`None\`). Now: returns what was fetched so far with a warning. First-page failure still returns None so downstream can distinguish "no data" from "partial".

**Currency guard — USD-only aggregation**
Aggregates (\`gross_cents\`, \`monthly\`, \`refunded_cents\`, \`charges_succeeded\`) now filter to USD-only. Non-USD succeeded charges are excluded from the rollup with a warning that lists the currencies seen. Individual per-session and per-invoice records still preserve their own currency for downstream inspection. Multi-currency rollups aren't supported yet — the previous code silently mixed cents across currencies.

## Tests

Four new cases (21 total in the Stripe suite):

- \`test_pagination_partial_failure_returns_partial\` — page 1 succeeds with has_more, page 2 returns 503 → collector keeps page 1's charge in the aggregate + warns
- \`test_first_page_failure_returns_none\` — 503 on first charges page → account still returns with 0 charges
- \`test_non_usd_charges_excluded_from_aggregates\` — mixed USD + EUR + GBP → only USD in totals; warning lists both foreign currencies
- \`test_all_usd_no_warning\` — pure USD run emits no currency warning

Result: **21 passed** in the stripe suite; 3 pre-existing GSC failures elsewhere unrelated.

## Test plan

- [ ] \`python3 -m pytest tests/test_stripe.py -v\`
- [ ] Real-data check: \`python3 run.py --collect-only --platform stripe\` still returns identical numbers when all charges are USD (they are on both configured accounts)