### PR TITLE
Fix mentions persistence — store schema out of sync with collector

### DIFF
--- a/store.py
+++ b/store.py
@@ -379,62 +379,72 @@ def _process_stripe(collected: dict, sheets: dict, store_path: Path, now: str) -
 
 
 def _process_mentions(collected: dict, sheets: dict, store_path: Path, now: str) -> None:
+    """
+    Persist mentions. Matches the flat schema mentions.py returns:
+      HN         → {type, domain, title, url, hn_url, points, num_comments?, created_at}
+      Mastodon   → {created_at, from, content, url}
+      Bluesky    → {created_at, from, content, url}
+      GSC        → {domain, query, page, clicks, impressions, ctr, position}
+    """
     sources = collected.get("sources", {})
 
     hn_hits = sources.get("hacker_news", [])
     if hn_hits:
         df_new = pd.DataFrame([{
-            "object_id": h.get("objectID", ""),
+            "hn_url": h.get("hn_url", ""),
             "type": h.get("type", ""),
+            "domain": h.get("domain", ""),
             "title": h.get("title", ""),
             "url": h.get("url", ""),
-            "points": h.get("points", 0),
-            "num_comments": h.get("num_comments", 0),
+            "points": h.get("points", 0) or 0,
+            "num_comments": h.get("num_comments", 0) or 0,
             "created_at": h.get("created_at", ""),
-            "domain": h.get("domain", ""),
-        } for h in hn_hits if h.get("objectID")])
-        sheets["hn_mentions"] = _upsert(_load(store_path, "hn_mentions"), df_new, ["object_id"])
+        } for h in hn_hits if h.get("hn_url")])
+        if not df_new.empty:
+            sheets["hn_mentions"] = _upsert(_load(store_path, "hn_mentions"), df_new, ["hn_url"])
 
     masto_mentions = sources.get("mastodon", [])
     if masto_mentions:
         df_new = pd.DataFrame([{
-            "notification_id": m.get("id", ""),
-            "account": m.get("account", {}).get("acct", "") if isinstance(m.get("account"), dict) else "",
-            "content": str(m.get("status", {}).get("content", "") if isinstance(m.get("status"), dict) else "")[:300],
+            "url": m.get("url", ""),
+            "from": m.get("from", ""),
+            "content": str(m.get("content", ""))[:300],
             "created_at": m.get("created_at", ""),
-        } for m in masto_mentions if m.get("id")])
-        sheets["mastodon_mentions"] = _upsert(
-            _load(store_path, "mastodon_mentions"), df_new, ["notification_id"]
-        )
+        } for m in masto_mentions if m.get("url")])
+        if not df_new.empty:
+            sheets["mastodon_mentions"] = _upsert(
+                _load(store_path, "mastodon_mentions"), df_new, ["url"]
+            )
 
     bsky_mentions = sources.get("bluesky", [])
     if bsky_mentions:
         df_new = pd.DataFrame([{
-            "uri": m.get("uri", m.get("cid", "")),
-            "author": m.get("author", {}).get("handle", "") if isinstance(m.get("author"), dict) else "",
-            "text": str(m.get("record", {}).get("text", "") if isinstance(m.get("record"), dict) else "")[:300],
-            "indexed_at": m.get("indexedAt", ""),
-        } for m in bsky_mentions])
-        if not df_new.empty and "uri" in df_new.columns:
+            "url": m.get("url", ""),
+            "from": m.get("from", ""),
+            "content": str(m.get("content", ""))[:300],
+            "created_at": m.get("created_at", ""),
+        } for m in bsky_mentions if m.get("url")])
+        if not df_new.empty:
             sheets["bluesky_mentions"] = _upsert(
-                _load(store_path, "bluesky_mentions"), df_new, ["uri"]
+                _load(store_path, "bluesky_mentions"), df_new, ["url"]
             )
 
     gsc_rows = sources.get("google_search_console", [])
     if gsc_rows:
         df_new = pd.DataFrame([{
-            "site": g.get("site", ""),
+            "domain": g.get("domain", ""),
             "query": g.get("query", ""),
             "page": g.get("page", ""),
-            "clicks": g.get("clicks", 0),
-            "impressions": g.get("impressions", 0),
+            "clicks": g.get("clicks", 0) or 0,
+            "impressions": g.get("impressions", 0) or 0,
             "ctr": g.get("ctr"),
             "position": g.get("position"),
             "last_updated": now,
         } for g in gsc_rows])
-        sheets["gsc_queries"] = _upsert(
-            _load(store_path, "gsc_queries"), df_new, ["site", "query", "page"]
-        )
+        if not df_new.empty:
+            sheets["gsc_queries"] = _upsert(
+                _load(store_path, "gsc_queries"), df_new, ["domain", "query", "page"]
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -732,3 +732,114 @@ class TestUpdate:
         result = _load(path, "account_snapshots")
         assert len(result) == 1
         assert result.iloc[0]["platform"] == "mastodon"
+
+
+# ---------------------------------------------------------------------------
+# _process_mentions — flat schema (matches what collectors/mentions.py returns)
+# ---------------------------------------------------------------------------
+
+class TestProcessMentions:
+    def _collected(self):
+        return {
+            "sources": {
+                "hacker_news": [
+                    {
+                        "type": "story",
+                        "domain": "cate.blog",
+                        "title": "How to X",
+                        "url": "https://cate.blog/how-to-x",
+                        "hn_url": "https://news.ycombinator.com/item?id=1",
+                        "points": 42,
+                        "num_comments": 7,
+                        "created_at": "2026-03-01",
+                    },
+                ],
+                "mastodon": [
+                    {
+                        "created_at": "2026-03-02",
+                        "from": "alice@fosstodon.org",
+                        "content": "nice post!",
+                        "url": "https://fosstodon.org/@alice/12345",
+                    },
+                ],
+                "bluesky": [
+                    {
+                        "created_at": "2026-03-03",
+                        "from": "bob.bsky.social",
+                        "content": "great read",
+                        "url": "https://bsky.app/profile/bob.bsky.social/post/abc",
+                    },
+                ],
+                "google_search_console": [
+                    {
+                        "domain": "cate.blog",
+                        "query": "raccoon",
+                        "page": "https://cate.blog/raccoon",
+                        "clicks": 5,
+                        "impressions": 100,
+                        "ctr": 5.0,
+                        "position": 3.1,
+                    },
+                ],
+            }
+        }
+
+    def test_writes_hn_mentions(self, tmp_path):
+        sheets = {}
+        _process_mentions(self._collected(), sheets, tmp_path / "s.xlsx", NOW)
+        assert "hn_mentions" in sheets
+        row = sheets["hn_mentions"].iloc[0]
+        assert row["hn_url"].startswith("https://news.ycombinator.com/")
+        assert row["domain"] == "cate.blog"
+        assert row["points"] == 42
+
+    def test_writes_mastodon_mentions(self, tmp_path):
+        sheets = {}
+        _process_mentions(self._collected(), sheets, tmp_path / "s.xlsx", NOW)
+        assert "mastodon_mentions" in sheets
+        row = sheets["mastodon_mentions"].iloc[0]
+        assert row["from"] == "alice@fosstodon.org"
+        assert row["content"] == "nice post!"
+
+    def test_writes_bluesky_mentions(self, tmp_path):
+        sheets = {}
+        _process_mentions(self._collected(), sheets, tmp_path / "s.xlsx", NOW)
+        assert "bluesky_mentions" in sheets
+        row = sheets["bluesky_mentions"].iloc[0]
+        assert row["from"] == "bob.bsky.social"
+
+    def test_writes_gsc_queries(self, tmp_path):
+        sheets = {}
+        _process_mentions(self._collected(), sheets, tmp_path / "s.xlsx", NOW)
+        assert "gsc_queries" in sheets
+        row = sheets["gsc_queries"].iloc[0]
+        assert row["domain"] == "cate.blog"
+        assert row["query"] == "raccoon"
+
+    def test_upserts_by_url_dedupes_across_runs(self, tmp_path):
+        """Same mention URL from two runs should upsert to a single row."""
+        path = tmp_path / "s.xlsx"
+        collected = self._collected()
+
+        # First run: write the sheet so it exists on disk
+        sheets1 = {}
+        _process_mentions(collected, sheets1, path, NOW)
+        with pd.ExcelWriter(path, engine="openpyxl") as w:
+            sheets1["mastodon_mentions"].to_excel(w, sheet_name="mastodon_mentions", index=False)
+
+        # Second run with the same data: existing row should be replaced, not appended
+        sheets2 = {}
+        _process_mentions(collected, sheets2, path, NOW)
+        assert len(sheets2["mastodon_mentions"]) == 1
+
+    def test_empty_sources_writes_nothing(self, tmp_path):
+        sheets = {}
+        _process_mentions({"sources": {"hacker_news": [], "mastodon": [], "bluesky": []}}, sheets, tmp_path / "s.xlsx", NOW)
+        assert sheets == {}
+
+    def test_missing_url_dropped(self, tmp_path):
+        """A mention with no url can't be upserted, so it's dropped."""
+        sheets = {}
+        collected = {"sources": {"mastodon": [{"from": "x", "content": "y", "created_at": "2026-01"}]}}
+        _process_mentions(collected, sheets, tmp_path / "s.xlsx", NOW)
+        assert "mastodon_mentions" not in sheets


### PR DESCRIPTION
## Summary

The mentions collector normalises HN / Mastodon / Bluesky notifications into a flat schema (`{created_at, from, content, url}` etc.), but `_process_mentions` in `store.py` was still expecting the raw API shape (Algolia HN hit with `objectID`, raw Mastodon notification with nested `account`/`status`, raw Bluesky post with nested `author`/`record`). The row-filters (`if h.get("objectID")` etc.) dropped every record silently, and the `hn_mentions`, `mastodon_mentions`, `bluesky_mentions` sheets stayed at zero rows across every run since the collector was rewritten.

## Fix

`_process_mentions` now matches the current flat schema:

| Source | Key | Columns |
|---|---|---|
| HN | `hn_url` | type, domain, title, url, points, num_comments, created_at |
| Mastodon | `url` | from, content, created_at |
| Bluesky | `url` | from, content, created_at |
| GSC | (domain, query, page) | clicks, impressions, ctr, position, last_updated |

Also fixes GSC's key column (`domain` not `site`, matching the collector).

## Tests

New \`TestProcessMentions\` in \`tests/test_store.py\`:

- \`test_writes_hn_mentions\` — HN sheet gets written with the expected columns
- \`test_writes_mastodon_mentions\` — same for Mastodon
- \`test_writes_bluesky_mentions\` — same for Bluesky
- \`test_writes_gsc_queries\` — GSC sheet with domain key
- \`test_upserts_by_url_dedupes_across_runs\` — same URL from two runs collapses to one row
- \`test_empty_sources_writes_nothing\` — no-op when all sources empty
- \`test_missing_url_dropped\` — records without a URL are dropped (no upsert key)

Result: **81 passed** in \`test_store.py\` + \`test_stripe.py\`.

## Backfill impact

Running \`store.update({\"mentions\": <current snapshot>})\` immediately lands **6 HN + 180 Mastodon + 4 Bluesky mentions** into the store. Future runs will accumulate normally.

## Test plan

- [ ] \`python3 -m pytest tests/test_store.py::TestProcessMentions -v\`
- [ ] After merge, next \`python3 run.py\` populates the mentions sheets