### PR TITLE
stripe: configurable lookback window (stripe_since_days)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Gives you the search queries that bring people to your site and which pages they
    ```
 4. Labels (`primary`, `secondary`, whatever you call them) are yours to choose — the collector groups everything by label.
 5. Checkout session metadata is preserved intact so you can classify sales by whatever product/cohort/tag scheme you use.
+6. `stripe_since_days` (default 60) sets how far back Stripe data is pulled when no `--months` lookback is given, so month-to-date and recent activity are covered. Set `0` to fall back to the collector's 14-day default.
 
 ---
 

--- a/collectors/_dispatch.py
+++ b/collectors/_dispatch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from collectors.mastodon import collect_mastodon
@@ -46,6 +46,30 @@ def _resolve_stripe_tokens(config: dict) -> dict[str, str]:
         if label and v:
             tokens[label] = str(v)
     return tokens
+
+
+def _stripe_since(config: dict, since: datetime | None) -> datetime | None:
+    """
+    Resolve the Stripe lookback window.
+
+    An explicit global `since` (e.g. from ``--months``) always wins. Otherwise
+    use ``stripe_since_days`` from config (default 60) so month-to-date and
+    recent activity are covered — the collector's own 14-day default is too
+    short for monthly rollups, and Stripe history is cheap to over-fetch.
+
+    A non-positive ``stripe_since_days`` falls back to the collector's internal
+    default (returns None).
+    """
+    if since is not None:
+        return since
+    days = config.get("stripe_since_days", 60)
+    try:
+        days = int(days)
+    except (TypeError, ValueError):
+        days = 60
+    if days <= 0:
+        return None
+    return datetime.now(timezone.utc) - timedelta(days=days)
 
 
 PLATFORM_COLLECTORS = {
@@ -196,7 +220,7 @@ def collect_all(
             if not tokens:
                 logger.info("Stripe: no tokens configured — skipping")
                 return
-            data = collect_stripe(tokens, since=since)
+            data = collect_stripe(tokens, since=_stripe_since(config, since))
         else:
             logger.error("Unknown platform: %s", name)
             return

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -99,6 +99,12 @@ vercel_team_id:                        # Team ID if the project is in a team (op
 #
 # The collector preserves checkout session metadata intact so downstream
 # analysis can classify sales by whatever product/cohort scheme you use.
+#
+# stripe_since_days: how far back to pull Stripe data when no global --months
+# lookback is given. Default 60, so month-to-date and recent activity are
+# covered (the collector's own fallback is only 14 days). Set 0 to use that
+# 14-day fallback instead.
+# stripe_since_days: 60
 
 # --- Content strategy ---
 # primary_focus: the metric or outcome you care about most. Claude uses this to frame

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -58,6 +58,9 @@ class TestResolveTokens:
         # "stripe_token" (no trailing _label) has no suffix → skipped
         assert _resolve_stripe_tokens(cfg) == {}
 
+    def test_no_tokens_returns_empty(self):
+        assert _resolve_stripe_tokens({}) == {}
+
 
 # ---------------------------------------------------------------------------
 # Lookback window (_stripe_since)
@@ -90,9 +93,6 @@ class TestStripeSince:
         got = _stripe_since({"stripe_since_days": "not-a-number"}, None)
         after = datetime.now(timezone.utc) - timedelta(days=60)
         assert before <= got <= after
-
-    def test_no_tokens_returns_empty(self):
-        assert _resolve_stripe_tokens({}) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -4,7 +4,7 @@ All HTTP is mocked with respx; no real Stripe key needed.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pandas as pd
@@ -12,7 +12,7 @@ import pytest
 import respx
 
 from collectors.stripe import collect_stripe
-from collectors._dispatch import _resolve_stripe_tokens
+from collectors._dispatch import _resolve_stripe_tokens, _stripe_since
 from store import _process_stripe, _load
 
 SINCE = datetime(2025, 12, 1, tzinfo=timezone.utc)
@@ -57,6 +57,39 @@ class TestResolveTokens:
         cfg = {"stripe_token": "should-not-appear", "other_key": "x"}
         # "stripe_token" (no trailing _label) has no suffix → skipped
         assert _resolve_stripe_tokens(cfg) == {}
+
+
+# ---------------------------------------------------------------------------
+# Lookback window (_stripe_since)
+# ---------------------------------------------------------------------------
+
+class TestStripeSince:
+    def test_explicit_since_wins(self):
+        # An explicit global since always overrides stripe_since_days.
+        assert _stripe_since({"stripe_since_days": 5}, SINCE) == SINCE
+
+    def test_default_is_60_days(self):
+        before = datetime.now(timezone.utc) - timedelta(days=60)
+        got = _stripe_since({}, None)
+        after = datetime.now(timezone.utc) - timedelta(days=60)
+        assert before <= got <= after
+
+    def test_configured_days_used(self):
+        before = datetime.now(timezone.utc) - timedelta(days=90)
+        got = _stripe_since({"stripe_since_days": 90}, None)
+        after = datetime.now(timezone.utc) - timedelta(days=90)
+        assert before <= got <= after
+
+    def test_non_positive_falls_back_to_collector_default(self):
+        # 0 / negative → None, letting collect_stripe use its own default.
+        assert _stripe_since({"stripe_since_days": 0}, None) is None
+        assert _stripe_since({"stripe_since_days": -3}, None) is None
+
+    def test_bad_value_falls_back_to_60(self):
+        before = datetime.now(timezone.utc) - timedelta(days=60)
+        got = _stripe_since({"stripe_since_days": "not-a-number"}, None)
+        after = datetime.now(timezone.utc) - timedelta(days=60)
+        assert before <= got <= after
 
     def test_no_tokens_returns_empty(self):
         assert _resolve_stripe_tokens({}) == {}


### PR DESCRIPTION
## What & why
The Stripe collector's internal default lookback is 14 days, too short for month-to-date sales rollups and recent-activity views. This adds a generic `stripe_since_days` config (default **60**), resolved at dispatch time via a new `_stripe_since(config, since)` helper.

- An explicit global `--months` lookback still wins.
- `stripe_since_days: 0` (or negative) falls back to the collector's own 14-day default.
- Fully generic — no downstream/product-specific logic. Groundwork for a downstream (private) DRI sales surface that needs MTD.

## Tests
Full suite passes (**379 passed**). Added `TestStripeSince` covering: explicit-since precedence, the 60-day default, a configured value, non-positive fallback to None, and bad-value fallback to 60.

## Docs
Updated `config.example.yaml` and README Stripe section.

## Validation
Ran `python -m pytest tests/ -q` → 379 passed.