### PR TITLE
Harden _stripe_since — clamp large values, pin remaining input shapes

### DIFF
--- a/collectors/_dispatch.py
+++ b/collectors/_dispatch.py
@@ -48,6 +48,9 @@ def _resolve_stripe_tokens(config: dict) -> dict[str, str]:
     return tokens
 
 
+_STRIPE_SINCE_MAX_DAYS = 3650  # 10 years — generous ceiling, guards against OverflowError
+
+
 def _stripe_since(config: dict, since: datetime | None) -> datetime | None:
     """
     Resolve the Stripe lookback window.
@@ -57,8 +60,12 @@ def _stripe_since(config: dict, since: datetime | None) -> datetime | None:
     recent activity are covered — the collector's own 14-day default is too
     short for monthly rollups, and Stripe history is cheap to over-fetch.
 
-    A non-positive ``stripe_since_days`` falls back to the collector's internal
-    default (returns None).
+    - A non-positive ``stripe_since_days`` (0, negative) falls back to the
+      collector's internal default (returns None).
+    - Malformed values (None, non-numeric strings) also fall back to the
+      60-day default.
+    - Very large values are clamped to a 10-year ceiling so a runaway config
+      value can't raise ``OverflowError`` inside ``timedelta``.
     """
     if since is not None:
         return since
@@ -69,6 +76,7 @@ def _stripe_since(config: dict, since: datetime | None) -> datetime | None:
         days = 60
     if days <= 0:
         return None
+    days = min(days, _STRIPE_SINCE_MAX_DAYS)
     return datetime.now(timezone.utc) - timedelta(days=days)
 
 

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -94,6 +94,42 @@ class TestStripeSince:
         after = datetime.now(timezone.utc) - timedelta(days=60)
         assert before <= got <= after
 
+    def test_explicit_none_falls_back_to_60(self):
+        # int(None) raises TypeError → caught → default 60
+        before = datetime.now(timezone.utc) - timedelta(days=60)
+        got = _stripe_since({"stripe_since_days": None}, None)
+        after = datetime.now(timezone.utc) - timedelta(days=60)
+        assert before <= got <= after
+
+    def test_numeric_string_used(self):
+        # "90" is a valid int() input → treated as 90 days
+        before = datetime.now(timezone.utc) - timedelta(days=90)
+        got = _stripe_since({"stripe_since_days": "90"}, None)
+        after = datetime.now(timezone.utc) - timedelta(days=90)
+        assert before <= got <= after
+
+    def test_float_value_truncated_to_int(self):
+        # int(60.9) == 60, standard Python truncation
+        before = datetime.now(timezone.utc) - timedelta(days=60)
+        got = _stripe_since({"stripe_since_days": 60.9}, None)
+        after = datetime.now(timezone.utc) - timedelta(days=60)
+        assert before <= got <= after
+
+    def test_sub_one_float_truncates_to_zero_and_returns_none(self):
+        # int(0.5) == 0 → non-positive branch → None. Documented foot-gun.
+        assert _stripe_since({"stripe_since_days": 0.5}, None) is None
+
+    def test_huge_value_clamped_to_ceiling(self):
+        # 10 ** 8 days would overflow timedelta; must clamp, not crash.
+        got = _stripe_since({"stripe_since_days": 10 ** 8}, None)
+        assert got is not None
+        # Result is clamped to ~10 years back — never further
+        assert got > datetime.now(timezone.utc) - timedelta(days=3651)
+
+    def test_returns_tz_aware_datetime(self):
+        got = _stripe_since({}, None)
+        assert got is not None and got.tzinfo is not None
+
 
 # ---------------------------------------------------------------------------
 # collect_stripe


### PR DESCRIPTION
## Summary

Follow-up to #44 addressing the non-blocking review suggestions.

**Behaviour changes:**
- Clamp \`stripe_since_days\` at a 10-year ceiling (\`_STRIPE_SINCE_MAX_DAYS = 3650\`) so a runaway config value can't raise \`OverflowError\` inside \`timedelta\`. Previously, values around \`10**8\` would push the resulting datetime before year 1 and crash the whole collect.

**Docstring:**
- Explicitly documents the malformed-value fallback (None / non-numeric string → 60) and the clamp

**Tests — six new cases in \`TestStripeSince\`:**
- \`test_explicit_none_falls_back_to_60\` — \`int(None)\` raises TypeError → caught → default 60
- \`test_numeric_string_used\` — \`\"90\"\` → 90 days (documents intentional string-int coercion)
- \`test_float_value_truncated_to_int\` — 60.9 → 60 (standard Python truncation)
- \`test_sub_one_float_truncates_to_zero_and_returns_none\` — 0.5 → None (documented foot-gun)
- \`test_huge_value_clamped_to_ceiling\` — \`10**8\` doesn't crash, result bounded by 10 years
- \`test_returns_tz_aware_datetime\` — result is UTC-aware (safety net for \`collect_stripe\` datetime comparisons)

## Not addressed here

The CHANGELOG note (14 → 60 default is a behaviour change for existing users on upgrade) — the repo doesn't yet have a CHANGELOG. Not worth adding one just for this.

## Tests

\`\`\`
385 passed
\`\`\`

## Test plan

- [ ] \`pytest tests/test_stripe.py::TestStripeSince -v\`
- [ ] \`grep _STRIPE_SINCE_MAX_DAYS collectors/_dispatch.py\` returns the constant