### PR TITLE
stripe: capture checkout promotion code (discount_code)

### DIFF
--- a/collectors/stripe.py
+++ b/collectors/stripe.py
@@ -57,6 +57,19 @@ def _all_pages(
     return out
 
 
+def _discount_code(session: dict) -> str | None:
+    """Human-facing promotion code used at checkout, if any.
+
+    Reads the checkout session's expanded ``discounts[].promotion_code.code``.
+    Returns None when no promo code was applied (or it wasn't expanded).
+    """
+    for d in session.get("discounts") or []:
+        pc = d.get("promotion_code")
+        if isinstance(pc, dict) and pc.get("code"):
+            return pc["code"]
+    return None
+
+
 def _collect_one_account(
     label: str,
     token: str,
@@ -79,7 +92,10 @@ def _collect_one_account(
         )
         sessions = _all_pages(
             client, auth, "checkout/sessions",
-            {"limit": 100, "created[gte]": since_ts},
+            # Expand the promotion code so we can capture the human-facing code
+            # used at checkout (a referral signal), not just the ID.
+            {"limit": 100, "created[gte]": since_ts,
+             "expand[]": "data.discounts.promotion_code"},
         )
         # Invoices need an extra scope — soft-fail
         invoices = _all_pages(
@@ -133,6 +149,7 @@ def _collect_one_account(
             "currency": s.get("currency"),
             "metadata": s.get("metadata") or {},
             "customer_email": (s.get("customer_details") or {}).get("email"),
+            "discount_code": _discount_code(s),
         })
 
     # Invoice records with line-item descriptions preserved.

--- a/store.py
+++ b/store.py
@@ -342,6 +342,7 @@ def _process_stripe(collected: dict, sheets: dict, store_path: Path, now: str) -
                 "amount_cents": s.get("amount_cents") or 0,
                 "currency": (s.get("currency") or "").upper() or currency,
                 "customer_email": s.get("customer_email") or "",
+                "discount_code": s.get("discount_code") or "",
                 "metadata_json": _json.dumps(s.get("metadata") or {}, sort_keys=True),
                 "last_updated": now,
             })

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -429,6 +429,17 @@ class TestCollectStripe:
         ]
         assert [i["id"] for i in real_only] == ["in_real"]
 
+    def test_discount_code_extraction(self):
+        from collectors.stripe import _discount_code
+        assert _discount_code({}) is None
+        assert _discount_code({"discounts": []}) is None
+        # coupon but no promotion code -> None
+        assert _discount_code({"discounts": [{"coupon": "c_1"}]}) is None
+        # unexpanded promotion_code id (a string) -> None
+        assert _discount_code({"discounts": [{"promotion_code": "promo_123"}]}) is None
+        # expanded promotion code -> the human code
+        assert _discount_code({"discounts": [{"promotion_code": {"code": "PARTNER10"}}]}) == "PARTNER10"
+
 
 # ---------------------------------------------------------------------------
 # Store persistence
@@ -448,7 +459,7 @@ class TestProcessStripe:
                     "paid_sessions": [
                         {"id": "cs_1", "created": 1740000000, "amount_cents": 49900,
                          "currency": "usd", "metadata": {"courseName": "A"},
-                         "customer_email": "x@y.com"},
+                         "customer_email": "x@y.com", "discount_code": "PARTNER10"},
                     ],
                     "paid_invoices": [
                         {"id": "in_1", "created": 1741000000,
@@ -472,6 +483,7 @@ class TestProcessStripe:
         assert len(sheets["stripe_monthly"]) == 2
         assert sheets["stripe_sessions"].iloc[0]["session_id"] == "cs_1"
         assert "courseName" in sheets["stripe_sessions"].iloc[0]["metadata_json"]
+        assert sheets["stripe_sessions"].iloc[0]["discount_code"] == "PARTNER10"
         inv_row = sheets["stripe_invoices"].iloc[0]
         assert inv_row["invoice_id"] == "in_1"
         assert inv_row["attempt_count"] == 1
@@ -506,15 +518,3 @@ class TestProcessStripe:
         _process_stripe(collected, sheets, store_path, "2026-07-10 12:00:00")
         rows = sheets["stripe_monthly"]
         assert set(rows["account"]) == {"a", "b"}
-
-
-def test_discount_code_extraction():
-    from collectors.stripe import _discount_code
-    assert _discount_code({}) is None
-    assert _discount_code({"discounts": []}) is None
-    # coupon but no promotion code -> None
-    assert _discount_code({"discounts": [{"coupon": "c_1"}]}) is None
-    # unexpanded promotion_code id (a string) -> None
-    assert _discount_code({"discounts": [{"promotion_code": "promo_123"}]}) is None
-    # expanded promotion code -> the human code
-    assert _discount_code({"discounts": [{"promotion_code": {"code": "PARTNER10"}}]}) == "PARTNER10"

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -506,3 +506,15 @@ class TestProcessStripe:
         _process_stripe(collected, sheets, store_path, "2026-07-10 12:00:00")
         rows = sheets["stripe_monthly"]
         assert set(rows["account"]) == {"a", "b"}
+
+
+def test_discount_code_extraction():
+    from collectors.stripe import _discount_code
+    assert _discount_code({}) is None
+    assert _discount_code({"discounts": []}) is None
+    # coupon but no promotion code -> None
+    assert _discount_code({"discounts": [{"coupon": "c_1"}]}) is None
+    # unexpanded promotion_code id (a string) -> None
+    assert _discount_code({"discounts": [{"promotion_code": "promo_123"}]}) is None
+    # expanded promotion code -> the human code
+    assert _discount_code({"discounts": [{"promotion_code": {"code": "PARTNER10"}}]}) == "PARTNER10"


### PR DESCRIPTION
**What & why:** the Stripe collector kept `discountPct` but not *which* promo code was used. The code is a referral signal — a partner or newsletter code (TECHTEA, REFACTORING, ENGMANAGER200…) often identifies the source even when the "how did you hear" free-text is blank. dri-data's attribution (dri-ops#47) consumes this.

**Change:** expand `data.discounts.promotion_code` on the `checkout/sessions` list; add a top-level `discount_code` to each paid-session record (None when no code).

**Tests:** all stripe tests pass (34) + a new `_discount_code` extraction test.

**Validated on real data:** a 6-month `--collect-only` run captured codes across both accounts. In dri-data's attribution this widened DRI-purchase coverage from 4 → 12 (8 purchases had a code but no free-text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)