### PR TITLE
Fix silent 3-month backfill re-collect on every run (#51)

### DIFF
--- a/run.py
+++ b/run.py
@@ -706,24 +706,37 @@ def main() -> None:
         # Persistent store — upsert into analytics.xlsx
         # ------------------------------------------------------------------
         if collected and not args.platform:
-            from store import update as store_update, get_known_platforms, STORE_PATH
+            import time as _time
+            from store import update as store_update, get_known_platforms, storable_platforms, STORE_PATH
 
+            # Only backfill for platforms we actually persist. Otherwise
+            # anything collected-but-not-stored (calendly, goatcounter,
+            # oreilly, upcoming) looks perpetually "new" and triggers a
+            # silent 3-month re-collect on every run — see #51.
+            # `mentions` is separately excluded: it IS persisted, but its
+            # sheets are named `hn_mentions`, `mastodon_mentions`, etc.,
+            # which `get_known_platforms` (prefix-based) can never detect,
+            # so it would also look perpetually new.
             known = get_known_platforms()
-            new_platforms = set(collected.keys()) - known - {"upcoming", "mentions"}
+            new_platforms = (set(collected.keys()) & storable_platforms()) - known - {"mentions"}
 
             if new_platforms and since is None:
-                # First time seeing these platforms — backfill 3 months
                 logger.info(
                     "Store: new platform(s) detected (%s) — backfilling 3 months",
                     ", ".join(sorted(new_platforms)),
                 )
                 backfill_since = datetime.now(timezone.utc) - timedelta(days=90)
+                t_backfill = _time.monotonic()
                 backfill = collect_all(
                     config,
                     platform=None,
                     since=backfill_since,
                 )
                 store_update(backfill)
+                logger.info(
+                    "Store: backfill complete (%.1fs)",
+                    _time.monotonic() - t_backfill,
+                )
             else:
                 store_update(collected)
 

--- a/store.py
+++ b/store.py
@@ -478,6 +478,11 @@ _PROCESSORS = {
 }
 
 
+def storable_platforms() -> set[str]:
+    """Platforms with a registered upsert handler — the ones that end up in analytics.xlsx."""
+    return set(_PROCESSORS.keys())
+
+
 def update(collected: dict[str, Any], store_path: Path = STORE_PATH) -> None:
     """
     Upsert all collected platform data into the persistent Excel store.

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -15,11 +15,17 @@ import yaml
 
 import run
 from run import since_last_run
+from store import storable_platforms as _real_storable_platforms
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+# Mirror of store.storable_platforms() — cached at import so every store
+# MagicMock below returns the real set without depending on the actual module.
+_STORABLE = _real_storable_platforms()
+
 
 def _write_config(path: Path, data: dict) -> None:
     with path.open("w") as f:
@@ -333,7 +339,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=mock_save_prompt),
         }):
             run.main()
@@ -348,7 +354,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known, STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
@@ -365,7 +371,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=MagicMock(), get_known_platforms=MagicMock(return_value=set()), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=MagicMock(), get_known_platforms=MagicMock(return_value=set()), storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=mock_save_prompt),
         }):
             run.main()
@@ -382,7 +388,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=MagicMock()),
-            "store": MagicMock(update=MagicMock(), get_known_platforms=MagicMock(return_value=set()), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=MagicMock(), get_known_platforms=MagicMock(return_value=set()), storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=mock_save_prompt),
         }):
             run.main()
@@ -397,7 +403,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=mock_store_update, get_known_platforms=MagicMock(return_value=set()), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=mock_store_update, get_known_platforms=MagicMock(return_value=set()), storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
@@ -413,7 +419,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
@@ -432,13 +438,75 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
 
         assert mock_collect.call_count == 1
         mock_store_update.assert_called_once_with({"mastodon": {"posts": []}})
+
+    def test_non_storable_platform_never_triggers_backfill(self, tmp_path, monkeypatch):
+        # Regression for #51: platforms without a store handler (calendly,
+        # goatcounter, oreilly) were perpetually "new" and re-triggered a
+        # 3-month collect_all on every run.
+        data_dir, _ = _setup_main(tmp_path, monkeypatch, ["--collect-only"])
+        collected = {
+            "mastodon": {"posts": []},
+            "calendly": {"events": []},
+            "goatcounter": {"stats": {}},
+            "oreilly": {"payments": []},
+        }
+        mock_collect = MagicMock(return_value=collected)
+        mock_store_update = MagicMock()
+        # mastodon is known; the three non-storable platforms are not — but
+        # they must not count as "new" for backfill purposes.
+        mock_get_known = MagicMock(return_value={"mastodon"})
+
+        with patch.dict("sys.modules", {
+            "collect": MagicMock(collect_all=mock_collect),
+            "store": MagicMock(update=mock_store_update, get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "analyse": MagicMock(save_prompt=MagicMock()),
+        }):
+            run.main()
+
+        assert mock_collect.call_count == 1, "backfill fired for non-storable platforms"
+        mock_store_update.assert_called_once_with(collected)
+
+    def test_mentions_never_triggers_backfill(self, tmp_path, monkeypatch):
+        # Regression for #51: mentions IS persisted, but its sheets are
+        # prefixed `hn_`, `mastodon_`, `bluesky_`, `gsc_` — never `mentions_` —
+        # so get_known_platforms() (prefix-based) can never detect it as known.
+        # Must be excluded to avoid a perpetual backfill on every run.
+        data_dir, _ = _setup_main(tmp_path, monkeypatch, ["--collect-only"])
+        collected = {"mastodon": {"posts": []}, "mentions": {"sources": {}}}
+        mock_collect = MagicMock(return_value=collected)
+        mock_get_known = MagicMock(return_value={"mastodon"})
+
+        with patch.dict("sys.modules", {
+            "collect": MagicMock(collect_all=mock_collect),
+            "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "analyse": MagicMock(save_prompt=MagicMock()),
+        }):
+            run.main()
+
+        assert mock_collect.call_count == 1, "backfill fired for mentions"
+
+    def test_backfill_logs_completion(self, tmp_path, monkeypatch, caplog):
+        data_dir, _ = _setup_main(tmp_path, monkeypatch, ["--collect-only"])
+        mock_collect = MagicMock(return_value={"mastodon": {"posts": []}})
+        mock_get_known = MagicMock(return_value=set())  # forces backfill
+
+        with patch.dict("sys.modules", {
+            "collect": MagicMock(collect_all=mock_collect),
+            "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "analyse": MagicMock(save_prompt=MagicMock()),
+        }):
+            with caplog.at_level("INFO"):
+                run.main()
+
+        assert any("backfilling 3 months" in r.message for r in caplog.records)
+        assert any("backfill complete" in r.message for r in caplog.records)
 
     def test_months_flag_sets_since(self, tmp_path, monkeypatch):
         data_dir, _ = _setup_main(tmp_path, monkeypatch, ["--months", "3", "--collect-only"])
@@ -447,7 +515,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known, STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known, storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
@@ -473,7 +541,7 @@ class TestMain:
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
             "store": MagicMock(update=MagicMock(), get_known_platforms=mock_get_known,
-                               STORE_PATH=tmp_path / "analytics.xlsx"),
+                               storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
@@ -490,7 +558,7 @@ class TestMain:
 
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
-            "store": MagicMock(update=mock_store_update, get_known_platforms=MagicMock(return_value=set()), STORE_PATH=tmp_path / "analytics.xlsx"),
+            "store": MagicMock(update=mock_store_update, get_known_platforms=MagicMock(return_value=set()), storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()
@@ -700,7 +768,7 @@ class TestNonInteractiveStaleness:
         with patch.dict("sys.modules", {
             "collect": MagicMock(collect_all=mock_collect),
             "store": MagicMock(update=MagicMock(), get_known_platforms=MagicMock(return_value=set()),
-                               STORE_PATH=tmp_path / "analytics.xlsx"),
+                               storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
             "analyse": MagicMock(save_prompt=MagicMock()),
         }):
             run.main()  # must not sys.exit()
@@ -736,7 +804,7 @@ class TestNonInteractiveStaleness:
             with patch.dict("sys.modules", {
                 "collect": MagicMock(collect_all=mock_collect),
                 "store": MagicMock(update=MagicMock(), get_known_platforms=MagicMock(return_value=set()),
-                                   STORE_PATH=tmp_path / "analytics.xlsx"),
+                                   storable_platforms=MagicMock(return_value=_STORABLE), STORE_PATH=tmp_path / "analytics.xlsx"),
                 "analyse": MagicMock(save_prompt=MagicMock()),
             }):
                 run.main()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -312,12 +312,14 @@ def _setup_main(tmp_path, monkeypatch, argv: list[str]):
     """Patch paths and sys.argv; return a fake config file."""
     config_path = tmp_path / "config.yaml"
     data_dir = tmp_path / "data" / "weekly"
+    platform_dir = tmp_path / "data" / "platform"
     reports_dir = tmp_path / "reports"
     data_dir.mkdir(parents=True)
 
     _write_config(config_path, _minimal_config())
     monkeypatch.setattr(run, "CONFIG_PATH", config_path)
     monkeypatch.setattr(run, "DATA_DIR", data_dir)
+    monkeypatch.setattr(run, "PLATFORM_DIR", platform_dir)
     monkeypatch.setattr(run, "REPORTS_DIR", reports_dir)
     monkeypatch.setattr(sys, "argv", ["run.py"] + argv)
     return data_dir, reports_dir

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,6 +10,7 @@ from store import (
     _load,
     _upsert,
     get_known_platforms,
+    storable_platforms,
     update,
     _process_mastodon,
     _process_bluesky,
@@ -138,6 +139,26 @@ class TestGetKnownPlatforms:
         path.write_bytes(b"not an excel file")
         result = get_known_platforms(path)
         assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# storable_platforms
+# ---------------------------------------------------------------------------
+
+class TestStorablePlatforms:
+    def test_matches_registered_processors(self):
+        # Every entry must correspond to a real _process_* handler so callers
+        # can trust the set for backfill/detection logic (see #51).
+        expected = {
+            "mastodon", "bluesky", "jetpack", "linkedin", "buttondown",
+            "posthog", "amazon", "mentions", "stripe",
+        }
+        assert storable_platforms() == expected
+
+    def test_excludes_platforms_without_handler(self):
+        # These are collected but not persisted — must NOT be reported as storable.
+        for name in ("calendly", "goatcounter", "oreilly", "upcoming"):
+            assert name not in storable_platforms()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #51 — `run.py` was silently re-running `collect_all` with a 90-day lookback after every collect finished, adding ~2m40s of unlogged work that looked like a hang and caused wrappers with a timeout to report the run as failed.
- Root cause was in `run.py`'s backfill trigger: `set(collected.keys()) - known - {"upcoming", "mentions"}` flagged calendly/goatcounter/oreilly as "new" on every run — they're collected but have no store handler, so `get_known_platforms()` can never return them.
- Not a lingering-thread / GSC / SDK issue (my initial guesses in the issue thread) — instrumented `main()` with `threading.enumerate()` at exit and only MainThread was alive.

## What changed

- New `store.storable_platforms()` — public helper returning `_PROCESSORS.keys()` as a set.
- `run.py` now intersects collected keys with `storable_platforms()` before the diff against `known`, so any platform without a store handler drops out. `mentions` stays hardcoded-excluded (its sheets are prefixed `hn_` / `mastodon_` / `bluesky_` / `gsc_`, never `mentions_`, so the prefix-based `get_known_platforms` can't detect it either).
- Added `"Store: backfill complete (Ns)"` log so any legitimate future backfill doesn't look like a hang either.

## Validation

- **Tests**: all 402 pass. New coverage: `TestStorablePlatforms`, `test_non_storable_platform_never_triggers_backfill`, `test_mentions_never_triggers_backfill`, `test_backfill_logs_completion`. Existing `test_new_platform_triggers_backfill` and `test_known_platform_no_backfill` updated to mock the new helper.
- **Real data**: `python run.py --collect-only` dropped from **338s → 163s** (halved because `collect_all` runs once, not twice). No backfill fires. Process exits cleanly right after `Store: updated`.

## Test plan

- [x] `python -m pytest tests/ -v` — 402 passed
- [x] `python run.py --collect-only` on real config — no backfill, clean exit
- [ ] Merge and confirm the strategy-review skill's wrapper no longer reports timeout on the next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
